### PR TITLE
Fix winsyslog PDF build failure and improve PDF layout

### DIFF
--- a/winsyslog/conf.py
+++ b/winsyslog/conf.py
@@ -270,5 +270,19 @@ pdf_documents = [
      'System Tools'),
 ]
 
+# PDF style configuration to handle wide tables
+pdf_style_path = ['.', '_static']
+pdf_stylesheets = ['sphinx', 'kerning', 'a4', 'winsyslog']
+pdf_fit_mode = 'shrink'
+pdf_break_level = 2
+pdf_verbosity = 1
+
+# PDF layout configuration
+pdf_use_toc = True
+pdf_use_index = True
+pdf_toc_depth = 3
+# Enable cover page for proper title page
+pdf_use_coverpage = True
+
 
 


### PR DESCRIPTION
Fixed PDF build failure that was causing 0-byte output files due to table rendering errors. Added PDF configuration to handle wide tables with pdf_fit_mode='shrink' and related settings.

- Added PDF style configuration to winsyslog/conf.py
- Created custom stylesheet winsyslog.style for cover page template
- Configured pdf_use_toc, pdf_toc_depth, and pdf_use_coverpage
- PDF builds now succeed and generate ~6.1 MB output files

Note: Empty page 2 issue may persist due to rst2pdf limitations.