### PR TITLE
Use Alabaster for CHM builds and improve build-chm.bat robustness

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -172,3 +172,19 @@ CHM output. The executable is no longer bundled with this repository.
 
 When `HHC` is not available, the Makefile will still build HTML output but skip
 the final CHM compilation step.
+
+**Note:** CHM builds use the Alabaster theme (not Furo) for compatibility with
+the Windows HTML Help viewer's IE/Trident engine, which does not support modern
+CSS features like custom properties.
+
+**Batch helper for CHM compilation (Windows):** If you build HTMLHelp from WSL
+(or another environment where `hhc.exe` cannot run), use the `build-chm.bat`
+script from Windows (cmd or PowerShell) to compile all CHM files:
+
+```cmd
+make all-htmlhelp   REM from WSL – generates HTMLHelp files, skips CHM
+build-chm.bat       REM from Windows – compiles all .hhp to .chm
+```
+
+You can override the compiler path: `set HHC=C:\path\to\hhc.exe` before
+running `build-chm.bat`.

--- a/Makefile
+++ b/Makefile
@@ -235,10 +235,10 @@ htmlhelp-%: FORCE
 	$(call check_project,$*)
 	$(call print_build_start,$*,HTMLHelp)
 	@$(MKDIR) $(BUILDDIR)/chm/$*
-	@$(SPHINXBUILD) -b htmlhelp -c $* $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/chm/$*
+	@SPHINX_BUILDER=htmlhelp $(SPHINXBUILD) -b htmlhelp -c $* $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/chm/$*
 	@if [ -n "$(HHC)" ]; then \
 		echo "$(COLOR_YELLOW)Compiling CHM file for $*...$(COLOR_RESET)"; \
-		$(HHC) $(BUILDDIR)/chm/$*/*.hhp || true; \
+		"$(HHC)" $(BUILDDIR)/chm/$*/*.hhp || true; \
 		if [ -f $(BUILDDIR)/chm/$*/*.chm ]; then \
 			$(CP) $(BUILDDIR)/chm/$*/*.chm $(BUILDDIR)/ 2>$(NULL_DEVICE) || true; \
 			echo "$(COLOR_GREEN)✓ CHM file created for $*$(COLOR_RESET)"; \

--- a/build-chm.bat
+++ b/build-chm.bat
@@ -1,0 +1,59 @@
+@echo off
+REM Compile all CHM files from build/chm/*/*.hhp
+REM Requires: HTML Help Workshop (hhc.exe). Run 'make all-htmlhelp' first.
+REM Override: set HHC=C:\path\to\hhc.exe
+
+REM Change to script directory (repo root) before enabling delayed expansion
+cd /d "%~dp0"
+setlocal EnableDelayedExpansion
+
+REM HTML Help Compiler - try HHC env var, then common install paths
+REM Use short path (PROGRA~2) to avoid (x86) parsing issues in batch
+if defined HHC (
+    set "HHC_PATH=!HHC!"
+) else (
+    set "HHC_PATH="
+    if exist "C:\PROGRA~2\HTMLHE~1\hhc.exe" set "HHC_PATH=C:\PROGRA~2\HTMLHE~1\hhc.exe"
+    if not defined HHC_PATH if exist "C:\Program Files\HTML Help Workshop\hhc.exe" set "HHC_PATH=C:\Program Files\HTML Help Workshop\hhc.exe"
+    if not defined HHC_PATH where hhc.exe >nul 2>&1 && set "HHC_PATH=hhc.exe"
+)
+
+if not defined HHC_PATH (
+    echo Error: HTML Help Compiler not found.
+    echo Install to: C:\Program Files ^(x86^)\HTML Help Workshop\  or set HHC env var
+    exit /b 1
+)
+
+set "BUILDDIR=build\chm"
+if not exist "%BUILDDIR%" (
+    echo Error: Build directory not found: %BUILDDIR%
+    echo Run 'make all-htmlhelp' first to generate HTMLHelp files.
+    exit /b 1
+)
+
+echo Compiling CHM files...
+echo.
+
+set "COUNT=0"
+for /d %%D in ("%BUILDDIR%\*") do (
+    for %%F in ("%%~D\*.hhp") do (
+        set /a COUNT+=1
+        echo [%%~nxD] Compiling %%~nF.hhp...
+        "!HHC_PATH!" "%%~F"
+        if !errorlevel! equ 0 (
+            echo   OK: CHM created
+            copy /y "%%~dpnF.chm" "build\" >nul 2>&1
+        ) else (
+            echo   Warning: CHM compilation failed
+        )
+        echo.
+    )
+)
+
+if !COUNT! equ 0 (
+    echo No .hhp files found. Run 'make all-htmlhelp' first.
+    exit /b 1
+)
+
+echo Done. Compiled !COUNT! CHM file(s).
+exit /b 0

--- a/conf_common.py
+++ b/conf_common.py
@@ -34,17 +34,20 @@ def get_spelling_word_list(current_file: str) -> str:
     return str(word_list)
 
 
+def get_shared_templates_path() -> str:
+    """Return path to shared templates (e.g. for CHM localStorage compatibility)."""
+    return str(Path(__file__).resolve().parent / "_templates")
+
+
 def enable_spelling_extension(extensions: List[str]) -> List[str]:
-    """Ensure the spelling builder is available when dependencies are installed."""
+    """Add spelling extension only when the package and Enchant C library are available."""
     if "sphinxcontrib.spelling" in extensions:
         return extensions
 
     try:
-        has_extension = importlib.util.find_spec("sphinxcontrib.spelling") is not None
-    except Exception:  # pragma: no cover - defensive guard for importlib issues
-        has_extension = False
-
-    if has_extension:
+        import sphinxcontrib.spelling  # noqa: F401
         extensions.append("sphinxcontrib.spelling")
+    except Exception:  # pragma: no cover - e.g. Enchant C library not installed
+        pass
 
     return extensions

--- a/eventreporter/conf.py
+++ b/eventreporter/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from conf_common import (
     enable_spelling_extension,
     get_spelling_word_list,
+    get_shared_templates_path,
     load_linkcheck_ignore,
 )
 
@@ -55,7 +56,9 @@ if 'tags' in globals():
     tags.add('eventreporter')
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# CHM uses Alabaster (no shared Furo override needed); HTML uses Furo + localStorage fix
+_building_htmlhelp = os.environ.get('SPHINX_BUILDER') == 'htmlhelp'
+templates_path = ['_templates'] if _building_htmlhelp else ['_templates', get_shared_templates_path()]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -156,7 +159,11 @@ sitemap_url_scheme = "{link}"
 sitemap_localtolinks = False
 sitemap_filename = "sitemap.xml"
 
-if importlib.util.find_spec("furo") is not None:
+# CHM viewer uses IE/Trident engine - Furo's CSS variables fail; use Alabaster for htmlhelp
+if _building_htmlhelp:
+    html_theme = "alabaster"
+    html_theme_options = {}
+elif importlib.util.find_spec("furo") is not None:
     html_theme = "furo"
     html_theme_options = {
         # Furo theme options (removed 'show_related' as it's not supported)

--- a/mwagent/conf.py
+++ b/mwagent/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from conf_common import (
     enable_spelling_extension,
     get_spelling_word_list,
+    get_shared_templates_path,
     load_linkcheck_ignore,
 )
 
@@ -55,7 +56,9 @@ if 'tags' in globals():
     tags.add('mwagent')
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# CHM uses Alabaster (no shared Furo override needed); HTML uses Furo + localStorage fix
+_building_htmlhelp = os.environ.get('SPHINX_BUILDER') == 'htmlhelp'
+templates_path = ['_templates'] if _building_htmlhelp else ['_templates', get_shared_templates_path()]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -121,7 +124,11 @@ sitemap_url_scheme = "{link}"
 sitemap_localtolinks = False
 sitemap_filename = "sitemap.xml"
 
-if importlib.util.find_spec("furo") is not None:
+# CHM viewer uses IE/Trident engine - Furo's CSS variables fail; use Alabaster for htmlhelp
+if _building_htmlhelp:
+    html_theme = "alabaster"
+    html_theme_options = {}
+elif importlib.util.find_spec("furo") is not None:
     html_theme = "furo"
     html_theme_options = {
         # Furo theme options (removed 'show_related' as it's not supported)

--- a/rsyslog/conf.py
+++ b/rsyslog/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from conf_common import (
     enable_spelling_extension,
     get_spelling_word_list,
+    get_shared_templates_path,
     load_linkcheck_ignore,
 )
 
@@ -55,7 +56,9 @@ if 'tags' in globals():
     tags.add('rsyslog')
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# CHM uses Alabaster (no shared Furo override needed); HTML uses Furo + localStorage fix
+_building_htmlhelp = os.environ.get('SPHINX_BUILDER') == 'htmlhelp'
+templates_path = ['_templates'] if _building_htmlhelp else ['_templates', get_shared_templates_path()]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -154,7 +157,11 @@ sitemap_url_scheme = "{link}"
 sitemap_localtolinks = False
 sitemap_filename = "sitemap.xml"
 
-if importlib.util.find_spec("furo") is not None:
+# CHM viewer uses IE/Trident engine - Furo's CSS variables fail; use Alabaster for htmlhelp
+if _building_htmlhelp:
+    html_theme = "alabaster"
+    html_theme_options = {}
+elif importlib.util.find_spec("furo") is not None:
     html_theme = "furo"
     html_theme_options = {
         # Furo theme options (removed 'show_related' as it's not supported)

--- a/syslogviewer/conf.py
+++ b/syslogviewer/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from conf_common import (
     enable_spelling_extension,
     get_spelling_word_list,
+    get_shared_templates_path,
     load_linkcheck_ignore,
 )
 
@@ -52,7 +53,9 @@ extensions = ['sphinx.ext.autodoc',
 extensions = enable_spelling_extension(extensions)
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# CHM uses Alabaster (no shared Furo override needed); HTML uses Furo + localStorage fix
+_building_htmlhelp = os.environ.get('SPHINX_BUILDER') == 'htmlhelp'
+templates_path = ['_templates'] if _building_htmlhelp else ['_templates', get_shared_templates_path()]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -198,7 +201,11 @@ sitemap_url_scheme = "{link}"
 sitemap_localtolinks = False
 sitemap_filename = "sitemap.xml"
 
-if importlib.util.find_spec("furo") is not None:
+# CHM viewer uses IE/Trident engine - Furo's CSS variables fail; use Alabaster for htmlhelp
+if _building_htmlhelp:
+    html_theme = "alabaster"
+    html_theme_options = {}
+elif importlib.util.find_spec("furo") is not None:
     html_theme = "furo"
     html_theme_options = {
         # Furo theme options (removed 'show_related' as it's not supported)

--- a/winsyslog-j/conf.py
+++ b/winsyslog-j/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from conf_common import (
     enable_spelling_extension,
     get_spelling_word_list,
+    get_shared_templates_path,
     load_linkcheck_ignore,
 )
 
@@ -56,7 +57,9 @@ if 'tags' in globals():
     tags.add('winsyslog_j')
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# CHM uses Alabaster (no shared Furo override needed); HTML uses Furo + localStorage fix
+_building_htmlhelp = os.environ.get('SPHINX_BUILDER') == 'htmlhelp'
+templates_path = ['_templates'] if _building_htmlhelp else ['_templates', get_shared_templates_path()]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -163,7 +166,11 @@ sitemap_url_scheme = "{link}"
 sitemap_localtolinks = False
 sitemap_filename = "sitemap.xml"
 
-if importlib.util.find_spec("furo") is not None:
+# CHM viewer uses IE/Trident engine - Furo's CSS variables fail; use Alabaster for htmlhelp
+if _building_htmlhelp:
+    html_theme = "alabaster"
+    html_theme_options = {}
+elif importlib.util.find_spec("furo") is not None:
     html_theme = "furo"
     html_theme_options = {
         # Furo theme options (removed 'show_related' as it's not supported)

--- a/winsyslog/conf.py
+++ b/winsyslog/conf.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from conf_common import (
     enable_spelling_extension,
     get_spelling_word_list,
+    get_shared_templates_path,
     load_linkcheck_ignore,
 )
 
@@ -55,7 +56,9 @@ if 'tags' in globals():
     tags.add('winsyslog')
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+# CHM uses Alabaster (no shared Furo override needed); HTML uses Furo + localStorage fix
+_building_htmlhelp = os.environ.get('SPHINX_BUILDER') == 'htmlhelp'
+templates_path = ['_templates'] if _building_htmlhelp else ['_templates', get_shared_templates_path()]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
@@ -165,7 +168,11 @@ sitemap_url_scheme = "{link}"
 sitemap_localtolinks = False
 sitemap_filename = "sitemap.xml"
 
-if importlib.util.find_spec("furo") is not None:
+# CHM viewer uses IE/Trident engine - Furo's CSS variables fail; use Alabaster for htmlhelp
+if _building_htmlhelp:
+    html_theme = "alabaster"
+    html_theme_options = {}
+elif importlib.util.find_spec("furo") is not None:
     html_theme = "furo"
     html_theme_options = {
         # Furo theme options (removed 'show_related' as it's not supported)


### PR DESCRIPTION
CHM output uses the Windows HTML Help viewer (IE/Trident), which does not support modern CSS (e.g. custom properties). Switch htmlhelp builds to Alabaster instead of Furo for correct rendering.

- Set SPHINX_BUILDER=htmlhelp in Makefile for htmlhelp builds
- Add get_shared_templates_path() in conf_common for HTML localStorage fix
- Use Alabaster for htmlhelp; keep Furo for regular HTML builds
- Fix build-chm.bat: delayed expansion order, 8.3 paths for HHC lookup, multiple install paths, quoted HHC invocation for paths with spaces
- Simplify spelling extension: try import instead of find_spec (handles missing Enchant C library)
- Document CHM theme choice and build-chm.bat usage in BUILDING.md
- Bump EventReporter version to 19.2