### PR TITLE
docs: remove outdated php-syslog-ng references

### DIFF
--- a/source/shared/spelling-wordlist.txt
+++ b/source/shared/spelling-wordlist.txt
@@ -1439,7 +1439,6 @@ performance-intense
 performance-optimizing-syslog-server
 performance-tests-and-results
 permittedsenders-options
-php-syslog-ng
 playsound-action
 pop3
 pop3probe
@@ -1787,7 +1786,6 @@ vbs
 vendor-specific
 version-history
 verticaltab
-w-to-setup-phpsyslogng-with-monitorware-products
 wa42
 waittime
 walkthrough

--- a/source/stepbystepguides.rst
+++ b/source/stepbystepguides.rst
@@ -82,8 +82,6 @@ Installations and Configurations
 
 - `Interactive logon/logoff Filter? <https://www.mwagent.com/step-by-step-guides/installation-and-configuration/interactive-logonlogoff-filter/>`_
 
-.. Instead of "How To setup php-syslog-ng with MonitorWare Products?" the product is no longer available
-
 - `How setup EventReporter to view EventLogs in Adiscon LogAnalyzer? <https://loganalyzer.adiscon.com/articles/how-to-setup-EventReporter-to-view-windows-eventlogs-in-adiscon-loganalyzer/>`_
 
 - `Monitoring MS ISA Firewall Logfiles via Syslog? <https://www.mwagent.com/step-by-step-guides/installation-and-configuration/monitoring-ms-isa-firewall-logfiles-via-syslog/>`_

--- a/source/winsyslogspecific/stepbystepguides.rst
+++ b/source/winsyslogspecific/stepbystepguides.rst
@@ -52,11 +52,6 @@ Installations and Configurations
   <https://www.winsyslog.com/step-by-step-guides/installation-and-configuration/mw
   agent-setup/>`_
 
-- `how to setup php-syslog-ng with monitorware products?
-  <https://www.winsyslog.com/step-by-step-guides/installation-and-configuration/ho
-  w-to-setup-phpsyslogng-with-monitorware-products/>`_
-
-
 services
 ^^^^^^^^
 


### PR DESCRIPTION
## What changed
- removed the outdated php-syslog-ng external link from WinSyslog step-by-step guides
- removed the legacy php-syslog-ng deprecation comment from the shared step-by-step index
- removed php-syslog-ng related entries from the shared spelling wordlist

## Why
The php-syslog-ng content is obsolete and refers to a product path that is no longer relevant for current documentation.

## Validation
- make all-html SPHINXOPTS="-W" (pass)
- make validate-rst could not run in this environment (python executable missing in Make target)
- make spelling could not run in this environment (spelling builder not registered)
