### PR TITLE
winsyslog docs: refine database tutorials

### DIFF
--- a/source/winsyslogspecific/faq/database-formats.rst
+++ b/source/winsyslogspecific/faq/database-formats.rst
@@ -76,12 +76,17 @@ Action path
 1. Decide whether you need the default supported schema or integration with an
    existing custom schema.
 2. Create and test an ODBC **System DSN** on the WinSyslog host.
-3. In WinSyslog, add a :doc:`Write to Database action <../../mwagentspecific/a-databaseoptions>`
+3. If the DSN uses Windows authentication, remember that WinSyslog normally
+   runs under the default Windows ``Local System`` service account unless you
+   changed it. For a remote SQL Server, either grant SQL access to that
+   service context, change the service logon account, or use SQL
+   authentication.
+4. In WinSyslog, add a :doc:`Write to Database action <../../mwagentspecific/a-databaseoptions>`
    to the ruleset that should store messages.
-4. For the default schema path, follow :doc:`../tutorial-database-logging`.
-5. For the custom integration path, follow
+5. For the default schema path, follow :doc:`../tutorial-database-logging`.
+6. For the custom integration path, follow
    :doc:`../tutorial-custom-database-integration`.
-6. Send a test message and verify that a row is inserted into the intended
+7. Send a test message and verify that a row is inserted into the intended
    table.
 
 Related information

--- a/source/winsyslogspecific/faq/database-logging-troubleshooting.rst
+++ b/source/winsyslogspecific/faq/database-logging-troubleshooting.rst
@@ -16,8 +16,8 @@ The most common causes are:
 
 - the DSN was created as a user DSN instead of a **System DSN**
 - the ODBC driver does not match the WinSyslog service architecture
-- the DSN works for the interactive user but not for the WinSyslog service
-  account
+- the DSN works for the interactive user but not for WinSyslog running under
+  its default ``Local System`` service account
 - the SQL account can connect but cannot insert into the target table
 - the table name in WinSyslog does not match the real table name
 - the field list still reflects the default schema instead of the custom table
@@ -45,8 +45,12 @@ Quick checks
    - Confirm that the DSN is a **System DSN**.
    - Confirm that the driver connects to the intended SQL Server instance and
      database.
-   - If the DSN uses Windows authentication, confirm that the WinSyslog
-     service account can also connect with the same DSN and database access.
+   - If the DSN uses Windows authentication, remember that WinSyslog normally
+     runs under the default Windows ``Local System`` service account unless you
+     changed it.
+   - A DSN test that succeeds for the interactive admin user does not prove
+     that the WinSyslog service can connect with the same DSN and database
+     access.
 
 2. Test the WinSyslog action connection.
 
@@ -90,9 +94,13 @@ Common failure patterns
 - **The DSN test works for the admin user, but WinSyslog still cannot write**
 
   This usually means the DSN or SQL permissions were only validated for the
-  interactive user account. Recheck the authentication mode and make sure the
-  WinSyslog service account can reach the same SQL Server instance and
-  database.
+  interactive user account. WinSyslog normally runs under the default Windows
+  ``Local System`` service account unless you changed it, so a remote SQL
+  Server may see a different account than your admin session.
+
+  Recheck the authentication mode and either grant SQL access to the WinSyslog
+  service account context, change the WinSyslog service to run under an
+  account that already has SQL access, or use SQL authentication instead.
 
 - **Rows appear, but values are missing or truncated**
 

--- a/source/winsyslogspecific/faq/database-logging-troubleshooting.rst
+++ b/source/winsyslogspecific/faq/database-logging-troubleshooting.rst
@@ -16,6 +16,8 @@ The most common causes are:
 
 - the DSN was created as a user DSN instead of a **System DSN**
 - the ODBC driver does not match the WinSyslog service architecture
+- the DSN works for the interactive user but not for the WinSyslog service
+  account
 - the SQL account can connect but cannot insert into the target table
 - the table name in WinSyslog does not match the real table name
 - the field list still reflects the default schema instead of the custom table
@@ -43,6 +45,8 @@ Quick checks
    - Confirm that the DSN is a **System DSN**.
    - Confirm that the driver connects to the intended SQL Server instance and
      database.
+   - If the DSN uses Windows authentication, confirm that the WinSyslog
+     service account can also connect with the same DSN and database access.
 
 2. Test the WinSyslog action connection.
 
@@ -82,6 +86,13 @@ Common failure patterns
   This usually means the table name, field list, or ruleset binding is wrong.
   Recheck the action settings and confirm that the incoming message actually
   triggers the rule.
+
+- **The DSN test works for the admin user, but WinSyslog still cannot write**
+
+  This usually means the DSN or SQL permissions were only validated for the
+  interactive user account. Recheck the authentication mode and make sure the
+  WinSyslog service account can reach the same SQL Server instance and
+  database.
 
 - **Rows appear, but values are missing or truncated**
 

--- a/source/winsyslogspecific/tutorial-custom-database-integration.rst
+++ b/source/winsyslogspecific/tutorial-custom-database-integration.rst
@@ -123,9 +123,14 @@ Steps
    - The DSN must point to the database that already contains your destination
      table.
    - Complete the DSN wizard and use its built-in test before you continue.
-   - If the DSN uses Windows authentication, confirm that the WinSyslog
-     service account can also connect to the same SQL Server instance and
-     database.
+   - If the DSN uses Windows authentication, remember that WinSyslog normally
+     runs under the default Windows ``Local System`` service account unless you
+     changed it. A DSN test that succeeds for the interactive admin user does
+     not prove that the WinSyslog service can connect to the same SQL Server
+     instance and database.
+   - For a remote SQL Server, either grant SQL access to the WinSyslog service
+     account context, change the WinSyslog service to run under an account
+     that already has SQL access, or use SQL authentication instead.
 
 3. Create or choose the ruleset whose messages should be stored.
 

--- a/source/winsyslogspecific/tutorial-custom-database-integration.rst
+++ b/source/winsyslogspecific/tutorial-custom-database-integration.rst
@@ -83,6 +83,30 @@ table could look like this:
        message_text nvarchar(max) NOT NULL
    );
 
+Sample message and output
+-------------------------
+
+This example uses the same RFC 5424-style message as the quick start so you
+can compare the default and custom-schema paths directly.
+
+Sample input message:
+
+.. code-block:: text
+
+   <134>1 2026-04-01T08:15:00Z fw01 sshd 1234 ID47 - Accepted password for alice from 192.0.2.10 port 55221
+
+Expected output in the example custom table:
+
+.. code-block:: text
+
+   received_at   = 2026-04-01 08:15:00
+   source_host   = fw01
+   facility_text = Local0
+   severity_text = Informational
+   app_name      = sshd
+   raw_message   = <134>1 2026-04-01T08:15:00Z fw01 sshd 1234 ID47 - Accepted password for alice from 192.0.2.10 port 55221
+   message_text  = Accepted password for alice from 192.0.2.10 port 55221
+
 Steps
 -----
 
@@ -99,8 +123,18 @@ Steps
    - The DSN must point to the database that already contains your destination
      table.
    - Complete the DSN wizard and use its built-in test before you continue.
+   - If the DSN uses Windows authentication, confirm that the WinSyslog
+     service account can also connect to the same SQL Server instance and
+     database.
 
 3. Create or choose the ruleset whose messages should be stored.
+
+   - If you are starting from scratch, create a dedicated ruleset for the
+     database action.
+   - Bind the receiving service to that same ruleset before you test inserts.
+   - If you already use an existing ruleset, confirm that the service that
+     receives the message is bound to the ruleset that holds the database
+     action.
 
 4. Add a :doc:`Write to Database <../mwagentspecific/a-databaseoptions>`
    action to that ruleset.

--- a/source/winsyslogspecific/tutorial-database-logging.rst
+++ b/source/winsyslogspecific/tutorial-database-logging.rst
@@ -163,9 +163,16 @@ Steps
    After the script finishes, open **Data Sources (ODBC)** and test the new
    System DSN before you continue.
 
-   If the DSN uses Windows authentication, test it with the same account
-   context that WinSyslog will use. A successful interactive admin test does
-   not prove that the WinSyslog service account can connect to SQL Server.
+   If the DSN uses Windows authentication, remember that WinSyslog normally
+   runs under the default Windows ``Local System`` service account unless you
+   changed it. A successful interactive admin test does not prove that the
+   WinSyslog service can connect to SQL Server.
+
+   For a remote SQL Server, either grant SQL access to the WinSyslog service
+   account context, change the WinSyslog service to run under an account that
+   already has SQL access, or use SQL authentication instead. The practical
+   verification step is to restart the WinSyslog service, send a test message,
+   and then check whether the row is inserted.
 
    You can also run this small PowerShell connection test against the DSN:
 

--- a/source/winsyslogspecific/tutorial-database-logging.rst
+++ b/source/winsyslogspecific/tutorial-database-logging.rst
@@ -91,7 +91,8 @@ Expected output in SQL Server:
 Prerequisites
 -------------
 
-- Microsoft SQL Server and SQL Server Management Studio (SSMS)
+- Microsoft SQL Server
+- SQL Server Management Studio (SSMS) if you want the GUI-based SQL workflow
 - Microsoft ODBC Driver 18 for SQL Server, or a compatible Microsoft SQL Server
   ODBC driver installed on the WinSyslog host
 - Database credentials with permission to connect, insert rows, and create
@@ -162,6 +163,10 @@ Steps
    After the script finishes, open **Data Sources (ODBC)** and test the new
    System DSN before you continue.
 
+   If the DSN uses Windows authentication, test it with the same account
+   context that WinSyslog will use. A successful interactive admin test does
+   not prove that the WinSyslog service account can connect to SQL Server.
+
    You can also run this small PowerShell connection test against the DSN:
 
    .. code-block:: powershell
@@ -184,9 +189,13 @@ Steps
 
 3. Create or choose the WinSyslog ruleset whose messages should be stored.
 
-   - If you are starting from scratch, use the ruleset that receives your
-     incoming syslog traffic.
-   - If you already have a working ruleset, reuse it.
+   - If you are starting from scratch, create a new ruleset for the database
+     action.
+   - Open the syslog listener service that should receive the test message and
+     bind it to that same ruleset.
+   - Make sure that service is enabled before you send the first test message.
+   - If you already have a working ruleset, confirm that the receiving service
+     is bound to the same ruleset that holds the database action.
 
 4. Add a :doc:`Write to Database <../mwagentspecific/a-databaseoptions>`
    action to that ruleset.


### PR DESCRIPTION
## Summary
- clarify how the receiving service must be bound to the same ruleset as the database action
- fix the prerequisite wording so SSMS is optional rather than required
- document the Windows-auth DSN vs WinSyslog service-account failure mode
- add a concrete sample message and expected output row to the custom-schema tutorial

## Validation
- `make validate-rst PYTHON=python3`
- `make all-html SPHINXOPTS="-W"`

## Notes
- This addresses the post-merge tutorial review findings except the importable config artifact, which is being handled separately.