### PR TITLE
Clarify listener binding and remote admin guidance across manuals

### DIFF
--- a/source/eventreporterspecific/faq.rst
+++ b/source/eventreporterspecific/faq.rst
@@ -31,6 +31,7 @@ Deployment and administration
 
    faq/mass-rollout-deployment
    faq/copying-configuration
+   ../shared/faq/remote-administration-and-browser-based-review
    faq/printable-manual
    faq/unc-path-support
    faq/database-formats

--- a/source/eventreporterspecific/store-and-forward.rst
+++ b/source/eventreporterspecific/store-and-forward.rst
@@ -39,3 +39,8 @@ Recommended setup path
 2. Add forwarding after filtering behaves the way you expect.
 3. Test remote targets early so host, port, authentication, and protocol
    mismatches are found before production rollout.
+
+For browser-based review of stored data, use Adiscon LogAnalyzer as a separate
+component. For the current split between service administration and
+browser-based review, see
+:doc:`../shared/faq/remote-administration-and-browser-based-review`.

--- a/source/eventreporterspecific/tutorial-use-with-loganalyzer.rst
+++ b/source/eventreporterspecific/tutorial-use-with-loganalyzer.rst
@@ -19,6 +19,10 @@ For EventReporter, the recommended LogAnalyzer path is database-backed storage.
 This avoids file-parser dependencies and is the most stable integration path in
 the current manual.
 
+LogAnalyzer is the browser-based review component for stored data. It is not
+the EventReporter service administration interface. For that distinction, see
+:doc:`../shared/faq/remote-administration-and-browser-based-review`.
+
 Prerequisites
 -------------
 

--- a/source/eventreporterspecific/understand-the-components.rst
+++ b/source/eventreporterspecific/understand-the-components.rst
@@ -28,6 +28,9 @@ How they fit together
 - The service continues using the currently applied configuration until you save
   or apply changes from the client.
 
+For the current split between remote administration and browser-based review,
+see :doc:`../shared/faq/remote-administration-and-browser-based-review`.
+
 What to read next
 -----------------
 

--- a/source/mwagentspecific/a-databaseoptions.rst
+++ b/source/mwagentspecific/a-databaseoptions.rst
@@ -369,7 +369,7 @@ Limit wait time doubling to
   nCacheWaittimeDoublingTimes
 
 **Description:**
-  Maximum number of retry doublings after repeated failures.
+  Maximum number of retry wait-time increases after repeated failures.
 
 Enable random wait time delay
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/mwagentspecific/a-oledbdatabaseaction.rst
+++ b/source/mwagentspecific/a-oledbdatabaseaction.rst
@@ -294,7 +294,7 @@ Limit wait time doubling to
   nCacheWaittimeDoublingTimes
 
 **Description:**
-  Maximum number of retry doublings after repeated failures.
+  Maximum number of retry wait-time increases after repeated failures.
 
 Enable random wait time delay
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/mwagentspecific/collect-and-monitor-data.rst
+++ b/source/mwagentspecific/collect-and-monitor-data.rst
@@ -20,6 +20,10 @@ MonitorWare Agent commonly starts with one or more of these service types:
 - probe and monitor services such as :doc:`pingprobe`, :doc:`portprobe`,
   :doc:`diskspacemonitor`, :doc:`cpumonitor`, and :doc:`ntservicemonitor`
 
+If you run multiple listener-style services, see
+:doc:`../shared/faq/listener-binding-rules` before reusing a protocol, IP
+address, and port combination.
+
 A practical first design
 ------------------------
 

--- a/source/mwagentspecific/faq.rst
+++ b/source/mwagentspecific/faq.rst
@@ -12,6 +12,7 @@ Deployment and licensing
 
    faq/enter-license-information
    faq/printable-manual
+   ../shared/faq/remote-administration-and-browser-based-review
    faq/mass-rollout-deployment
    faq/mass-update-rollout
    faq/diff-massroll-massupdateroll
@@ -46,6 +47,7 @@ Protocols and integration
 .. toctree::
    :maxdepth: 1
 
+   ../shared/faq/listener-binding-rules
    ../shared/faq/tls-listener-certificate-files
 
 Platform and compatibility

--- a/source/mwagentspecific/store-and-forward.rst
+++ b/source/mwagentspecific/store-and-forward.rst
@@ -34,3 +34,8 @@ useful.
 
 If reliable delivery across temporary outages matters, configure disk-backed
 queues where the action supports them.
+
+For browser-based review of stored data, use Adiscon LogAnalyzer as a separate
+component. For the current split between service administration and
+browser-based review, see
+:doc:`../shared/faq/remote-administration-and-browser-based-review`.

--- a/source/mwagentspecific/tutorial-use-with-loganalyzer.rst
+++ b/source/mwagentspecific/tutorial-use-with-loganalyzer.rst
@@ -19,6 +19,10 @@ For MonitorWare Agent, the recommended LogAnalyzer path is database-backed
 storage. This avoids file-parser dependencies and is the most stable
 integration path in the current manual.
 
+LogAnalyzer is the browser-based review component for stored data. It is not
+the MonitorWare Agent service administration interface. For that distinction,
+see :doc:`../shared/faq/remote-administration-and-browser-based-review`.
+
 Prerequisites
 -------------
 

--- a/source/mwagentspecific/understand-the-components.rst
+++ b/source/mwagentspecific/understand-the-components.rst
@@ -55,3 +55,6 @@ A typical setup looks like this:
 3. Events can be forwarded live to Interactive Syslog Viewer.
 4. Events can be stored in files or a database for later analysis in Adiscon
    LogAnalyzer.
+
+For the current split between remote administration and browser-based review,
+see :doc:`../shared/faq/remote-administration-and-browser-based-review`.

--- a/source/rsyslogwaspecific/collect-and-forward-windows-events.rst
+++ b/source/rsyslogwaspecific/collect-and-forward-windows-events.rst
@@ -32,6 +32,9 @@ Where to configure it
   need to watch text-based log files.
 - :doc:`Syslog server <../mwagentspecific/syslogserver>` is available when the
   agent should relay incoming syslog.
+- If you run multiple listener-style services, see
+  :doc:`../shared/faq/listener-binding-rules` before reusing a protocol, IP
+  address, and port combination.
 
 Quick verification
 ------------------

--- a/source/rsyslogwaspecific/store-and-forward.rst
+++ b/source/rsyslogwaspecific/store-and-forward.rst
@@ -38,3 +38,8 @@ Recommended setup path
 3. Add internal actions only after the forwarding path behaves as expected.
 4. If you need outage tolerance, configure disk-backed queues where the action
    supports it.
+
+If stored data is reviewed later in a browser, treat Adiscon LogAnalyzer as a
+separate downstream component. For the current split between service
+administration and browser-based review, see
+:doc:`../shared/faq/remote-administration-and-browser-based-review`.

--- a/source/rsyslogwaspecific/understand-the-components.rst
+++ b/source/rsyslogwaspecific/understand-the-components.rst
@@ -27,6 +27,9 @@ How they fit together
 - The service continues using the currently applied configuration until you
   save or apply changes from the client.
 
+For the current split between remote administration and browser-based review,
+see :doc:`../shared/faq/remote-administration-and-browser-based-review`.
+
 Optional downstream tools
 -------------------------
 

--- a/source/shared/faq/listener-binding-rules.rst
+++ b/source/shared/faq/listener-binding-rules.rst
@@ -1,0 +1,96 @@
+:orphan:
+
+.. _shared-listener-binding-rules:
+
+How Do Listener IP, Port, and Protocol Conflicts Work?
+======================================================
+
+Question
+--------
+
+When I create multiple listeners or server services, which combinations can
+run at the same time and which ones conflict?
+
+Answer
+------
+
+Treat each listener as binding to a local network endpoint. In practice, that
+endpoint is defined by the transport protocol, the local IP address, and the
+local port.
+
+Two listeners can run side by side only when their bindings do not conflict.
+Changing the protocol, IP address, or port avoids the conflict. If two
+listeners need the same binding, only one of them can own it.
+
+TLS does not change that rule. A TLS-enabled listener still binds a TCP port,
+so plain TCP and TCP+TLS cannot both listen on the same IP address and port.
+
+Details
+-------
+
+Use this rule of thumb:
+
+- Different transport protocols can coexist on the same port, for example
+  UDP/514 and TCP/514.
+- TCP and TCP+TLS cannot both use the same IP address and port, because both
+  bind TCP at the socket level.
+- Different ports can coexist, for example TCP/514 and TCP+TLS/1514.
+- Different local IP addresses can also coexist, as long as the listener type
+  exposes that setting.
+
+Short IP primer
+^^^^^^^^^^^^^^^
+
+The special address ``0.0.0.0`` means "all local IPv4 addresses" and ``::``
+means "all local IPv6 addresses". If a listener already binds ``0.0.0.0`` on a
+given protocol and port, another listener of the same protocol usually cannot
+reuse that port on one specific IPv4 address because the wildcard listener
+already covers it.
+
+Listener-specific differences
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The exact UI fields depend on the listener type:
+
+- Some listeners expose protocol, IP address, and port directly.
+- Some listeners expose only part of that combination.
+- Some listeners support only one transport mode and therefore do not offer a
+  protocol choice at all.
+- Some listeners separate IPv4 and IPv6 into different services or settings.
+
+The conflict rule still stays the same: one active listener per effective
+binding.
+
+Concrete examples
+^^^^^^^^^^^^^^^^^
+
+These combinations are valid:
+
+- UDP / ``0.0.0.0`` / ``514``
+- TCP / ``0.0.0.0`` / ``514``
+- TCP+TLS / ``0.0.0.0`` / ``1514``
+
+This combination conflicts:
+
+- TCP / ``0.0.0.0`` / ``514``
+- TCP+TLS / ``0.0.0.0`` / ``514``
+
+Action path
+-----------
+
+1. Identify the protocol, local IP address, and local port required by each
+   listener.
+2. Check whether any active listener already uses the same effective binding.
+3. If there is a conflict, change the port or bind to a different local IP
+   address when that listener type allows it.
+4. If TLS is required in parallel with plain TCP, plan separate bindings before
+   configuring the senders.
+5. After changing the listener side, update the senders so they use the new
+   destination port or IP address.
+
+Related information
+-------------------
+
+- :doc:`tls-listener-certificate-files`
+- Use the product-specific listener reference page for the exact UI fields of
+  the listener type you are configuring.

--- a/source/shared/faq/remote-administration-and-browser-based-review.rst
+++ b/source/shared/faq/remote-administration-and-browser-based-review.rst
@@ -1,0 +1,94 @@
+:orphan:
+
+.. _shared-remote-administration-and-browser-based-review:
+
+How Do Remote Administration and Browser-Based Log Review Fit Together?
+=======================================================================
+
+Question
+--------
+
+How do remote administration and browser-based log review work in the current
+Adiscon Windows products?
+
+Answer
+------
+
+Treat them as two separate functions.
+
+- Administrative changes are made with the Configuration Client, either on the
+  local system or through the remote-connect workflow when that product
+  supports it.
+- The current product family does not use a built-in browser administration
+  interface for service configuration.
+- Browser-based review is handled by Adiscon LogAnalyzer, which is a separate
+  and optional component for stored data. It is not the service administration
+  interface.
+
+Details
+-------
+
+Remote administration
+^^^^^^^^^^^^^^^^^^^^^
+
+The current product family uses the Windows Configuration Client for
+administration. Depending on the product and deployment style, you typically
+work in one of these ways:
+
+- connect to another machine from the client
+- export and import configuration
+- use a rollout process for repeated deployments
+
+This means remote administration is a client-and-deployment workflow, not a
+built-in browser administration console.
+
+When the client connects to another machine directly, the target system must be
+reachable over the network and the current user must have the required access
+rights on that remote machine.
+
+Browser-based log review
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adiscon LogAnalyzer is the browser-based component in this ecosystem. It is
+used to review data that has already been written to a file or database.
+It is deployed separately from the logging service and requires its own web
+server and PHP runtime.
+
+That split is important:
+
+- LogAnalyzer is for stored data review.
+- The logging service still receives, processes, and stores or forwards data.
+- The Configuration Client is still the place where you change service
+  settings.
+
+What this means operationally
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want both remote administration and browser-based visibility, plan them
+as separate pieces:
+
+1. Decide how the product configuration will be administered remotely.
+2. Decide where retained data will be stored.
+3. Deploy LogAnalyzer separately if browser-based review of stored data is
+   needed.
+
+Action path
+-----------
+
+1. Use the Configuration Client for administrative changes.
+2. If the target system is remote, use the product's remote-connect or
+   deployment workflow.
+3. Configure file or database storage for the data you want to review later.
+4. Deploy Adiscon LogAnalyzer separately on a web server if browser-based
+   review is required.
+5. Point LogAnalyzer at the same stored data source and verify end-to-end that
+   new rows appear there.
+
+Related information
+-------------------
+
+- :doc:`../tutorials/loganalyzer-setup-and-use`
+- Use the product-specific remote-connect page when the Configuration Client
+  can connect to another machine directly.
+- Use the product-specific rollout or configuration-copy guidance when you need
+  repeatable deployment across multiple systems.

--- a/source/winsyslogspecific/configuringwinsyslog-j.rst
+++ b/source/winsyslogspecific/configuringwinsyslog-j.rst
@@ -54,6 +54,10 @@ same port then an error message is logged into Windows Event Log that more than
 one instance of Syslog server is running. After which WinSyslog wouldn't be
 able to perform the desired action.
 
+For the general listener conflict rule, including why TCP and TCP+TLS cannot
+share the same IP address and port, see
+:doc:`../shared/faq/listener-binding-rules`.
+
 Theoretically, you can run a few hundred services in a single service instance.
 However, both from a usage scenario point of view as well as concerning
 operating system resources, we recommend limiting the services to a maximum of

--- a/source/winsyslogspecific/configuringwinsyslog.rst
+++ b/source/winsyslogspecific/configuringwinsyslog.rst
@@ -54,6 +54,10 @@ same port then an error message is logged into Windows Event Log that more than
 one instance of Syslog server is running. After which WinSyslog wouldn't be
 able to perform the desired action.
 
+For the general listener conflict rule, including why TCP and TCP+TLS cannot
+share the same IP address and port, see
+:doc:`../shared/faq/listener-binding-rules`.
+
 Theoretically, you can run a few hundred services in a single service instance.
 However, both from a usage scenario point of view as well as concerning
 operating system resources, we recommend limiting the services to a maximum of

--- a/source/winsyslogspecific/faq.rst
+++ b/source/winsyslogspecific/faq.rst
@@ -38,6 +38,7 @@ Deployment and administration
 
    faq/mass-rollout-deployment
    faq/copying-configuration
+   ../shared/faq/remote-administration-and-browser-based-review
    faq/printable-manual
    faq/unc-path-support
    faq/database-formats
@@ -48,6 +49,7 @@ Protocols and integration
 .. toctree::
    :maxdepth: 1
 
+   ../shared/faq/listener-binding-rules
    ../shared/faq/tls-listener-certificate-files
    faq/originating-ip-address
    faq/setp-vs-syslog

--- a/source/winsyslogspecific/producttour/receive-logs.rst
+++ b/source/winsyslogspecific/producttour/receive-logs.rst
@@ -28,6 +28,8 @@ Where to configure it:
 - :doc:`RELP listener <../../mwagentspecific/relplistener>` receives RELP.
 - :doc:`SETP server <../../mwagentspecific/setpserver>` receives SETP.
 - :doc:`SNMP trap receiver <../../mwagentspecific/snmptrapreceiver>` receives SNMP traps.
+- If you run multiple listeners, see :doc:`../../shared/faq/listener-binding-rules`
+  before reusing a port for another service.
 
 Quick verification:
 

--- a/source/winsyslogspecific/producttour/understand-the-components.rst
+++ b/source/winsyslogspecific/producttour/understand-the-components.rst
@@ -44,6 +44,9 @@ How they fit together
 - **LogAnalyzer** works on stored log data after the service has written it to
   a file or database.
 
+For the current split between remote administration and browser-based review,
+see :doc:`../../shared/faq/remote-administration-and-browser-based-review`.
+
 What to read next
 -----------------
 

--- a/source/winsyslogspecific/tutorial-use-with-loganalyzer.rst
+++ b/source/winsyslogspecific/tutorial-use-with-loganalyzer.rst
@@ -19,6 +19,10 @@ For WinSyslog, the recommended LogAnalyzer path is database-backed storage.
 This avoids file-parser dependencies and is the most stable integration path in
 the current manual.
 
+LogAnalyzer is the browser-based review component for stored data. It is not
+the WinSyslog service administration interface. For that distinction, see
+:doc:`../shared/faq/remote-administration-and-browser-based-review`.
+
 Prerequisites
 -------------
 


### PR DESCRIPTION
## Summary
- add shared canonical FAQs for listener binding conflicts and for the split between remote administration and browser-based log review
- surface those answers from WinSyslog, EventReporter, MonitorWare Agent, and rsyslog Windows Agent where users encounter listener setup, component roles, and LogAnalyzer usage
- keep the listener explanation concrete, including TCP vs TCP+TLS conflicts and the wildcard IP caveat

## Why
A recent customer discussion exposed two repeated points of confusion:
- which listener combinations can coexist on the same host
- whether these products have a built-in browser admin UI versus a separate browser-based review component

This change gives both humans and AI-facing retrieval a canonical answer, then links to it from the product pages where users are most likely to look first.

## Validation
- `make html-winsyslog SPHINXOPTS='-W'`
- `make html-eventreporter SPHINXOPTS='-W'`
- `make html-mwagent SPHINXOPTS='-W'`
- `make html-rsyslog SPHINXOPTS='-W'`
- `make all-html SPHINXOPTS='-W'`
- `make validate-rst`

## Notes
- `make spelling` still reports unrelated pre-existing `doublings` warnings in existing MWAgent shared action docs; this PR does not modify those pages.
- the local worktree still contains unrelated untracked helper files that were intentionally left out of this branch.