### PR TITLE
[codex] Align terminology in remaining Windows product manuals

### DIFF
--- a/source/eventreporterspecific/collect-windows-events.rst
+++ b/source/eventreporterspecific/collect-windows-events.rst
@@ -3,8 +3,9 @@
 Collect Windows Events
 ======================
 
-EventReporter collects Windows Event Log data and turns it into internal events
-that can be filtered, stored, and forwarded.
+EventReporter collects Windows Event Log data through configured input
+services and turns it into internal events that can be filtered, stored, and
+forwarded.
 
 What EventReporter receives
 ---------------------------
@@ -34,7 +35,7 @@ reason to use it for compatibility or legacy behavior.
 Quick verification
 ------------------
 
-- Configure one Event Log Monitor service.
+- Configure one Event Log Monitor input service.
 - Bind it to a ruleset with a visible action such as
   :doc:`Write to File <../mwagentspecific/a-fileoptions>`.
 - Apply the configuration and confirm that new Windows events reach the target.

--- a/source/eventreporterspecific/core-concepts.rst
+++ b/source/eventreporterspecific/core-concepts.rst
@@ -9,11 +9,15 @@ Concept map
 
 EventReporter processing follows this model:
 
-1. A **service** collects Windows Event Log data.
+1. An **input service** collects Windows Event Log data.
 2. The collected data becomes an **information unit** inside EventReporter.
 3. The **rule engine** evaluates the event against **rules** and
    **filter conditions**.
 4. Matching **actions** store, forward, or transform the event.
+
+In plain language, you can read this as:
+
+``input service -> ruleset -> action``
 
 Canonical concept pages
 -----------------------
@@ -33,7 +37,7 @@ Why this matters
 
 Understanding these concepts helps you:
 
-- design rulesets with predictable behavior
+- design rulesets with predictable behavior for each input service
 - avoid duplicate or conflicting processing paths
 - choose the right action type for storage, forwarding, or alerting
 - troubleshoot why an event did or did not match a rule

--- a/source/eventreporterspecific/creating-an-initial-configuration.rst
+++ b/source/eventreporterspecific/creating-an-initial-configuration.rst
@@ -6,6 +6,9 @@ Creating an Initial Configuration
 Use this page to build the first working EventReporter configuration: collect
 Windows Event Log events and write them to a local file.
 
+In this manual, **input** is the plain-language concept, while the configured
+object is a **service**.
+
 Goal
 ----
 
@@ -36,17 +39,17 @@ Steps
    - Inside the ruleset, add a :doc:`Write to File <../mwagentspecific/a-fileoptions>` action.
    - Choose an easy-to-find test file path.
 
-3. Create one event log monitor service.
+3. Create one event collection service.
 
    - Under :doc:`Services <services>`, add an
      :doc:`Event Log Monitor V2 <../mwagentspecific/eventlogmonitorv2>` service.
-   - Bind that service to the ruleset you created.
+   - Bind that input service to the ruleset you created.
    - Select at least one Windows event log or channel to monitor.
 
 4. Save and apply the configuration.
 
-   - Apply or save the changes in the Configuration Client so the service can
-     use them.
+   - Apply or save the changes in the Configuration Client so the input
+     service can use them.
    - Until you apply the changes, the running service continues to use the
      previous configuration.
 
@@ -60,8 +63,8 @@ How to verify
 3. If nothing arrives, check:
 
    - the EventReporter service is running
-   - the event log monitor service is enabled
-   - the service is bound to the correct ruleset
+   - the event collection service is enabled
+   - the input service is bound to the correct ruleset
    - the file action is inside that ruleset
    - the selected event log or channel actually produces events
 

--- a/source/eventreporterspecific/eventreporter.rst
+++ b/source/eventreporterspecific/eventreporter.rst
@@ -9,6 +9,10 @@ processes them through rules, and stores or forwards the results.
 If you are new to the product, start with ``Getting Started`` for the first
 working setup and return here for the detailed configuration pages.
 
+In this manual, **input** is the clearest plain-language concept for anything
+that collects events, while **service** remains the operational term for the
+configured EventReporter object.
+
 .. toctree::
    :maxdepth: 2
 

--- a/source/eventreporterspecific/services.rst
+++ b/source/eventreporterspecific/services.rst
@@ -3,18 +3,22 @@
 Services
 ========
 
-Services are the EventReporter inputs. They collect Windows event data and pass
-it to rulesets for further processing.
+Services are the configured EventReporter inputs. They collect Windows event
+data and pass it to rulesets for further processing.
 
 In EventReporter, the most important service types are the Windows Event Log
 monitor services. They read Windows events and make them available to the rule
 engine.
 
+In this manual, **input** is the clearest plain-language concept, while
+**service** remains the operational term for the configured EventReporter
+object.
+
 Important behavior
 ------------------
 
-- You must define at least one service, otherwise EventReporter has no event
-  data to process.
+- You must define at least one input service, otherwise EventReporter has no
+  event data to process.
 - A service instance is an active collector.
 - A service default is only a template. It does not collect anything until you
   create an actual service instance from it.

--- a/source/eventreporterspecific/understand-the-components.rst
+++ b/source/eventreporterspecific/understand-the-components.rst
@@ -11,22 +11,23 @@ The two main components
 
 1. **EventReporter Service**
    This is the runtime component. It runs in the background as a Windows
-   service, reads Windows Event Log data, evaluates rules, and then stores or
-   forwards matching events.
+   service, runs the configured input services, evaluates rules, and then
+   stores or forwards matching events.
 2. **EventReporter Configuration Client**
-   This is the administrative user interface. You use it to define services,
-   rulesets, filters, and actions. Changes are made in the Configuration
-   Client and then applied so the running EventReporter service can use the new
-   configuration.
+   This is the administrative user interface. You use it to define input
+   services, rulesets, filters, and actions. Changes are made in the
+   Configuration Client and then applied so the running EventReporter service
+   can use the new configuration.
 
 How they fit together
 ---------------------
 
-- The **service** performs the actual collection, filtering, storage, and
-  forwarding work.
-- The **configuration client** defines what the service should do.
-- The service continues using the currently applied configuration until you save
-  or apply changes from the client.
+- The **EventReporter service** performs the actual collection, filtering,
+  storage, and forwarding work through the configured input services.
+- The **configuration client** defines what those input services, rulesets,
+  and actions should do.
+- The runtime service continues using the currently applied configuration until
+  you save or apply changes from the client.
 
 For the current split between remote administration and browser-based review,
 see :doc:`../shared/faq/remote-administration-and-browser-based-review`.

--- a/source/index.eventreporter.rst
+++ b/source/index.eventreporter.rst
@@ -24,6 +24,11 @@ EventReporter is focused on Windows Event Log collection. It complements, but
 is distinct from products such as
 `WinSyslog <https://www.winsyslog.com/>`_, which focus on syslog reception.
 
+Inside the product, collected data is configured through **services** that feed
+events into rulesets. In plain language, you can read those services as the
+configured inputs that collect Windows Event Log data and hand it to the rule
+engine.
+
 For a neutral summary of how EventReporter and the other Adiscon Windows
 products can deliver data into ROSI-oriented deployments, see
 :doc:`shared/how-to-integrate-adiscon-windows-products-into-rosi`.

--- a/source/index.mwagent.rst
+++ b/source/index.mwagent.rst
@@ -6,6 +6,10 @@ product. It combines Windows Event Log collection, syslog and SETP reception,
 file and service monitoring, active probes, local filtering, and flexible
 forwarding and storage actions in one background service.
 
+Inside the product, collected or received data enters through configured
+**services**. In plain language, you can read those services as the configured
+inputs and generators that feed events into rulesets and actions.
+
 For a neutral summary of how MonitorWare Agent and the other Adiscon Windows
 products can deliver data into ROSI-oriented deployments, see
 :doc:`shared/how-to-integrate-adiscon-windows-products-into-rosi`.

--- a/source/index.rsyslog.rst
+++ b/source/index.rsyslog.rst
@@ -23,6 +23,10 @@ The product is centered on two main runtime roles:
 - the **rsyslog Windows Agent Configuration Client**, which defines services,
   rulesets, filters, and forwarding actions
 
+Inside the product, data enters through configured **services**. In plain
+language, you can read those services as the configured inputs that collect or
+receive events before rulesets and actions process them.
+
 This manual covers installation, first-time setup, configuration, tutorials,
 FAQ content, and reference material for rsyslog Windows Agent.
 

--- a/source/monitorwareconcepts.rst
+++ b/source/monitorwareconcepts.rst
@@ -1,8 +1,8 @@
 Core concepts
 =============
 
-Use this section to understand the core MonitorWare Agent model: services,
-information units, filter conditions, actions, rules, and SETP.
+Use this section to understand the core MonitorWare Agent model: input
+services, information units, filter conditions, actions, rules, and SETP.
 
 These concepts explain how the product collects monitoring data, evaluates it,
 and decides what to do next.

--- a/source/mwagentspecific/collect-and-monitor-data.rst
+++ b/source/mwagentspecific/collect-and-monitor-data.rst
@@ -8,7 +8,8 @@ more specialized manuals in this doc set.
 Typical input sources
 ---------------------
 
-MonitorWare Agent commonly starts with one or more of these service types:
+MonitorWare Agent commonly starts with one or more of these input service
+types:
 
 - :doc:`Event Log Monitor V2 <eventlogmonitorv2>` for Windows Event Log
   channels
@@ -20,8 +21,8 @@ MonitorWare Agent commonly starts with one or more of these service types:
 - probe and monitor services such as :doc:`pingprobe`, :doc:`portprobe`,
   :doc:`diskspacemonitor`, :doc:`cpumonitor`, and :doc:`ntservicemonitor`
 
-If you run multiple listener-style services, see
-:doc:`../shared/faq/listener-binding-rules` before reusing a protocol, IP
+If you run multiple input services, see
+:doc:`../shared/faq/listener-binding-rules` before reusing a transport, IP
 address, and port combination.
 
 A practical first design
@@ -29,8 +30,8 @@ A practical first design
 
 For a first working deployment, keep the design small:
 
-1. Choose one service that collects the data you care about first.
-2. Attach that service to a dedicated ruleset.
+1. Choose one input service that collects the data you care about first.
+2. Attach that input service to a dedicated ruleset.
 3. Add one simple action, such as write to file or forward via syslog.
 4. Verify that the expected events arrive.
 

--- a/source/mwagentspecific/configuringmwagent.rst
+++ b/source/mwagentspecific/configuringmwagent.rst
@@ -10,6 +10,10 @@ Configuration is created in the **MonitorWare Agent Configuration Client** and
 then applied to the **MonitorWare Agent Service**. Save and apply changes after
 editing so the running service uses the updated configuration.
 
+In this manual, **input** is the clearest plain-language concept for anything
+that collects or receives data, while **service** remains the operational term
+for the configured MonitorWare Agent object.
+
 .. toctree::
    :maxdepth: 1
 

--- a/source/mwagentspecific/creating-an-initial-configuration.rst
+++ b/source/mwagentspecific/creating-an-initial-configuration.rst
@@ -9,6 +9,9 @@ Goal
 Create a first working MonitorWare Agent configuration that collects Windows
 Event Log records and writes matching events to a local file.
 
+In this manual, **input** is the plain-language concept, while the configured
+object is a **service**.
+
 Prerequisites
 -------------
 
@@ -22,14 +25,14 @@ Steps
 1. Open the MonitorWare Agent Configuration Client.
 2. Under **Running Services**, add an
    :doc:`Event Log Monitor V2 <eventlogmonitorv2>` service.
-3. Assign that service to a new ruleset, for example `Initial Windows Events`.
+3. Assign that input service to a new ruleset, for example `Initial Windows Events`.
 4. In the ruleset, create one rule.
 5. Leave the filter condition broad for the first test, or add one simple
    filter such as an event source or event ID condition.
 6. Add a :doc:`Write to File <a-fileoptions>` action to the rule.
 7. Configure a local test path and filename.
 8. Save and apply the configuration in the Configuration Client so the running
-   service uses the new settings.
+   input service uses the new settings.
 9. Restart the MonitorWare Agent service if your environment or change-control
    process requires it.
 
@@ -40,7 +43,7 @@ How to verify
 2. Confirm that the configured output file is created or updated.
 3. If no output appears, check:
 
-   - whether the service is enabled
+   - whether the input service is enabled
    - whether the ruleset is assigned to that service
    - whether the filter condition is too restrictive
    - whether the output path is writable by the service account

--- a/source/mwagentspecific/process-and-filter.rst
+++ b/source/mwagentspecific/process-and-filter.rst
@@ -3,7 +3,7 @@ Process and Filter
 
 MonitorWare Agent processes incoming monitoring data in a consistent sequence:
 
-1. a service produces an information unit
+1. an input service produces an information unit
 2. the information unit enters the assigned ruleset
 3. each rule evaluates its filter conditions
 4. matching rules execute their actions in order
@@ -14,7 +14,8 @@ verified.
 What to filter on
 -----------------
 
-The available filter fields depend on the service type. Typical examples are:
+The available filter fields depend on the input service type. Typical examples
+are:
 
 - event ID, source, level, and channel for Event Log Monitor services
 - sender, facility, and severity for syslog input

--- a/source/mwagentspecific/services.rst
+++ b/source/mwagentspecific/services.rst
@@ -2,15 +2,19 @@ Services
 ========
 
 Use this section to configure how MonitorWare Agent collects data. Services are
-the product inputs. They gather events or measurements and pass them to the
-ruleset assigned to that service.
+the configured product inputs and generators. They gather events or
+measurements and pass them to the ruleset assigned to that service.
+
+In this manual, **input** is the clearest plain-language concept, while
+**service** remains the operational term for the configured MonitorWare Agent
+object.
 
 For example, the Syslog Server service accepts incoming syslog messages and
 Event Log Monitor extracts Windows Event Log data. Multiple service instances
 can run at the same time when their settings do not conflict.
 
-You must define at least one enabled service, otherwise the product does not
-collect any data and cannot do useful work.
+You must define at least one enabled input service, otherwise the product does
+not collect any data and cannot do useful work.
 
 Do not confuse configured services with **service defaults** in the tree view.
 Service defaults are templates. They provide default properties for new

--- a/source/mwagentspecific/store-and-forward.rst
+++ b/source/mwagentspecific/store-and-forward.rst
@@ -1,8 +1,8 @@
 Store and Forward
 =================
 
-After MonitorWare Agent collects and filters data, actions determine what
-happens next.
+After MonitorWare Agent collects and filters data through its input services,
+actions determine what happens next.
 
 Common destinations
 -------------------

--- a/source/mwagentspecific/understand-the-components.rst
+++ b/source/mwagentspecific/understand-the-components.rst
@@ -12,8 +12,8 @@ MonitorWare Agent Service
 The **MonitorWare Agent Service** is the core runtime component. It runs in the
 background and performs the actual work:
 
-- receives data from services such as Event Log Monitor, Syslog Server, SETP
-  Server, File Monitor, and probes
+- receives data from configured input services such as Event Log Monitor,
+  Syslog Server, SETP Server, File Monitor, and probes
 - evaluates rules and filter conditions
 - executes actions such as writing to file or database, forwarding via syslog
   or SETP, or sending notifications
@@ -22,7 +22,8 @@ Configuration Client
 --------------------
 
 The **MonitorWare Agent Configuration Client** is the administrative user
-interface. Use it to create services, rulesets, rules, filters, and actions.
+interface. Use it to create input services, rulesets, rules, filters, and
+actions.
 
 Changes made in the Configuration Client do not affect the running service
 until you save and apply the configuration. In operational terms, the client is
@@ -50,7 +51,7 @@ How They Work Together
 
 A typical setup looks like this:
 
-1. The Configuration Client defines services, rulesets, and actions.
+1. The Configuration Client defines input services, rulesets, and actions.
 2. The MonitorWare Agent Service runs that configuration in the background.
 3. Events can be forwarded live to Interactive Syslog Viewer.
 4. Events can be stored in files or a database for later analysis in Adiscon

--- a/source/rsyslogwaspecific/collect-and-forward-windows-events.rst
+++ b/source/rsyslogwaspecific/collect-and-forward-windows-events.rst
@@ -4,7 +4,8 @@ Collect and Forward Windows Events
 ==================================
 
 rsyslog Windows Agent is primarily used to collect Windows-originated events
-and forward them to rsyslog or another downstream receiver.
+through configured input services and forward them to rsyslog or another
+downstream receiver.
 
 What the product collects
 -------------------------
@@ -32,13 +33,13 @@ Where to configure it
   need to watch text-based log files.
 - :doc:`Syslog server <../mwagentspecific/syslogserver>` is available when the
   agent should relay incoming syslog.
-- If you run multiple listener-style services, see
-  :doc:`../shared/faq/listener-binding-rules` before reusing a protocol, IP
+- If you run multiple input services, see
+  :doc:`../shared/faq/listener-binding-rules` before reusing a transport, IP
   address, and port combination.
 
 Quick verification
 ------------------
 
-- Configure one collection service.
+- Configure one collection input service.
 - Bind it to a ruleset with a visible forwarding action.
 - Apply the configuration and confirm that new events reach the receiver.

--- a/source/rsyslogwaspecific/core-concepts.rst
+++ b/source/rsyslogwaspecific/core-concepts.rst
@@ -9,11 +9,15 @@ Concept map
 
 rsyslog Windows Agent processing follows this model:
 
-1. A **service** collects or receives an event.
+1. An **input service** collects or receives an event.
 2. The collected data becomes an **information unit** inside the product.
 3. The **rule engine** evaluates the event against **rules** and
    **filter conditions**.
 4. Matching **actions** forward, transform, or discard the event.
+
+In plain language, you can read this as:
+
+``input service -> ruleset -> action``
 
 Canonical concept pages
 -----------------------

--- a/source/rsyslogwaspecific/creatinganinitialconfiguration.rst
+++ b/source/rsyslogwaspecific/creatinganinitialconfiguration.rst
@@ -6,6 +6,9 @@ Creating an Initial Configuration
 Use this page to build the first working rsyslog Windows Agent configuration:
 collect Windows Event Log events and forward them to an rsyslog receiver.
 
+In this manual, **input** is the plain-language concept, while the configured
+object is a **service**.
+
 Goal
 ----
 
@@ -45,13 +48,13 @@ Steps
    - Under :doc:`Services <services>`, add an
      :doc:`Event Log Monitor V2 <../mwagentspecific/eventlogmonitorv2>`
      service.
-   - Bind that service to the ruleset you created.
+   - Bind that input service to the ruleset you created.
    - Select at least one Windows event log or channel to monitor.
 
 4. Save and apply the configuration.
 
-   - Apply or save the changes in the Configuration Client so the service can
-     use them.
+   - Apply or save the changes in the Configuration Client so the input
+     service can use them.
    - Until you apply the changes, the running service continues to use the
      previous configuration.
 
@@ -66,7 +69,7 @@ How to verify
 
    - the rsyslog Windows Agent service is running
    - the event collection service is enabled
-   - the service is bound to the correct ruleset
+   - the input service is bound to the correct ruleset
    - the forwarding action is inside that ruleset
    - the receiver host, port, and transport mode are correct
 

--- a/source/rsyslogwaspecific/rsyslogwa.rst
+++ b/source/rsyslogwaspecific/rsyslogwa.rst
@@ -9,10 +9,14 @@ events, processes them through rules, and forwards the results.
 If you are new to the product, start with ``Getting Started`` for the first
 working setup and return here for the detailed configuration pages.
 
+In this manual, **input** is the clearest plain-language concept for anything
+that collects or receives events, while **service** remains the operational
+term for the configured rsyslog Windows Agent object.
+
 Recommended setup path
 ----------------------
 
-1. Define inputs under :doc:`Services <services>` and bind each service to a
+1. Define input services under :doc:`Services <services>` and bind each service to a
    ruleset.
 2. Build processing under :doc:`Filter Conditions <filterconditions>`.
 3. Add forwarding or internal processing under :doc:`Actions <actions>`.

--- a/source/rsyslogwaspecific/services.rst
+++ b/source/rsyslogwaspecific/services.rst
@@ -1,11 +1,15 @@
 Services
 ========
 
-Services are the input side of rsyslog Windows Agent. They collect or receive
-events and send them into the assigned ruleset.
+Services are the configured input side of rsyslog Windows Agent. They collect
+or receive events and send them into the assigned ruleset.
 
-You must define at least one service. Without a service, the product does not
-collect or receive any event data.
+In this manual, **input** is the clearest plain-language concept, while
+**service** remains the operational term for the configured rsyslog Windows
+Agent object.
+
+You must define at least one input service. Without a service, the product does
+not collect or receive any event data.
 
 Defaults vs. active services
 ----------------------------

--- a/source/rsyslogwaspecific/understand-the-components.rst
+++ b/source/rsyslogwaspecific/understand-the-components.rst
@@ -11,21 +11,23 @@ The two main components
 
 1. **rsyslog Windows Agent Service**
    This is the runtime component. It runs in the background as a Windows
-   service, collects events, evaluates rules, and forwards matching data.
+   service, runs the configured input services, evaluates rules, and forwards
+   matching data.
 2. **rsyslog Windows Agent Configuration Client**
-   This is the administrative user interface. You use it to define services,
-   rulesets, filters, and actions. Changes are made in the Configuration
-   Client and then applied so the running service can use the new
+   This is the administrative user interface. You use it to define input
+   services, rulesets, filters, and actions. Changes are made in the
+   Configuration Client and then applied so the running service can use the new
    configuration.
 
 How they fit together
 ---------------------
 
-- The **service** performs the actual collection, filtering, and forwarding
-  work.
-- The **configuration client** defines what the service should do.
-- The service continues using the currently applied configuration until you
-  save or apply changes from the client.
+- The **rsyslog Windows Agent service** performs the actual collection,
+  filtering, and forwarding work through the configured input services.
+- The **configuration client** defines what those input services, rulesets,
+  and actions should do.
+- The runtime service continues using the currently applied configuration until
+  you save or apply changes from the client.
 
 For the current split between remote administration and browser-based review,
 see :doc:`../shared/faq/remote-administration-and-browser-based-review`.


### PR DESCRIPTION
## What changed
- applied the WinSyslog terminology cleanup pattern to the remaining Windows product manuals: EventReporter, MonitorWare Agent, and rsyslog Windows Agent
- clarified the user-facing processing model as `input service -> ruleset -> action` on the main concept, getting-started, and component pages
- kept existing GUI labels intact where the documentation must match the current client
- replaced older or more technical phrasing such as `listener-style services` with clearer transport-oriented wording where appropriate
- tightened the runtime-vs-configuration-client explanations so new users can better understand what runs in the background and what they configure in the UI

## Why this changed
The current manuals still use long-standing internal terminology that is harder for new users to map onto the product workflow. This PR makes the docs more consistent and easier to follow without changing the current GUI vocabulary.

## User impact
- onboarding should be clearer for administrators who are new to these products
- the manuals now explain services more explicitly as the configured inputs that feed rulesets and actions
- terminology is more consistent across the Windows product set, which should also improve AI retrieval and answer quality from generated HTML

## Validation
- `make all-html SPHINXOPTS='-W'`
- `make spelling`
- `make validate-rst PYTHON=python3` 
  - `doc8` passed
  - `rstcheck` is not installed in this environment, so that sub-step could not run here

## Notes
- local `LOCAL_*` helper notes were intentionally left untracked and are not part of this PR
- this PR keeps current GUI terms where the UI requires them; any GUI renaming belongs in the separate change request for the new configuration client