### PR TITLE
Document log rotation shutdown and restart guarantees

### DIFF
--- a/source/eventreporterspecific/faq/log-rotation-file-handle-cleanup.rst
+++ b/source/eventreporterspecific/faq/log-rotation-file-handle-cleanup.rst
@@ -1,15 +1,24 @@
 .. _log-rotation-file-handle-cleanup-eventreporter:
 
 
-Why are Logfiles sometimes not rotated in EventReporter 18.5 to 19.1?
-=====================================================================
+Why were dynamic log files sometimes not rotated in older EventReporter versions?
+=================================================================================
 
-This article explains why log files may sometimes not be rotated as expected in EventReporter versions 18.5 to 19.1, and provides solutions for this issue.
+Older EventReporter versions could miss some scheduled rotations when dynamic
+filenames were combined with file-handle cleanup. That historical behavior was
+improved in later versions of the shared log rotation subsystem.
+
+For the guarantees of the current subsystem, including graceful shutdown,
+restart recovery, reload behavior, and dynamic filename support, see
+:doc:`../../shared/faq/log-rotation-guarantees`.
 
 Background
 ----------
 
-In EventReporter versions 18.5 to 19.1, there are several factors that can interfere with log file rotation under certain circumstances. These issues were addressed in later versions with improved rotation handling.
+In older EventReporter versions, file-handle cleanup and scheduled rotation
+could interfere with each other when a dynamic log file had already become
+inactive before the scheduled rotation time arrived. Later versions improved
+the shared log rotation subsystem to handle this more reliably.
 
 The Problem
 -----------
@@ -65,3 +74,19 @@ If upgrading is not immediately possible, try these workarounds:
    * Consider load balancing if multiple instances are logging simultaneously
 
 **Important:** Monitor your logging environment closely when implementing these workarounds, as they may affect overall system performance.
+.. _log-rotation-file-handle-cleanup-eventreporter:
+
+Why were dynamic log files sometimes not rotated in older EventReporter versions?
+=================================================================================
+
+Older EventReporter versions could miss some scheduled rotations when dynamic
+filenames were combined with file-handle cleanup. That historical behavior was
+improved in later versions of the shared log rotation subsystem.
+
+For the guarantees of the current subsystem, including graceful shutdown,
+restart recovery, reload behavior, and dynamic filename support, see
+:doc:`../../shared/faq/log-rotation-guarantees`.
+
+If you are still running one of the older affected builds, increasing the file
+handle cleanup timeout can reduce the chance of a missed scheduled rotation,
+but the recommended long-term solution is to upgrade to a current release.

--- a/source/mwagentspecific/a-fileoptions.rst
+++ b/source/mwagentspecific/a-fileoptions.rst
@@ -497,6 +497,11 @@ Do not rotate files on Shutdown
   Do not rotate log files if service is stopped even with "Rotate each time a
   file is closed" enabled.
 
+  Detached log rotation work that was already queued or already active in the
+  background worker is still recovered on the next startup. This setting only
+  suppresses starting an additional rotate-on-close operation because the
+  service is shutting down.
+
 
 
 
@@ -570,6 +575,11 @@ Compress File After log rotation
 **Description:**
   Enable file compression after log rotation.
 
+  Compression runs in the asynchronous log rotation worker after the live file
+  has already been detached. If graceful shutdown happens while compression is
+  still running, the unfinished detached work is resumed on the next startup
+  instead of being abandoned.
+
 
 
 Compression Format
@@ -609,6 +619,10 @@ Move file after log rotation
 **Description:**
   Move logfile after rotation & compression.
 
+  Move-after-rotate uses the same asynchronous recovery model as compression.
+  If shutdown reaches the configured worker wait timeout before the move
+  finishes, the detached work is resumed on the next startup.
+
 
 Target directory
 ^^^^^^^^^^^^^^^^
@@ -618,3 +632,6 @@ Target directory
 
 **Description:**
   Location where to move the logfile after rotation & compression.
+
+For an overview of shutdown, restart, reload, and dynamic-filename guarantees,
+see :doc:`../shared/faq/log-rotation-guarantees`.

--- a/source/mwagentspecific/engine-options.rst
+++ b/source/mwagentspecific/engine-options.rst
@@ -70,8 +70,13 @@ Wait time if log rotation is running on service shutdown
 
 **Description**
    When service is being shutdown, this defines how much time the logrotate
-   background worker thread has left to finish its log rotations before a
-   forceful termination.
+   background worker thread has left to finish its log rotations before the
+   service exits.
+
+   If a queued or already active detached rotation does not finish within this
+   bounded wait time, the unfinished detached work is saved and resumed on the
+   next startup instead of extending shutdown indefinitely. For the full
+   guarantee, see :doc:`../shared/faq/log-rotation-guarantees`.
 
 Network specific Options
 ------------------------

--- a/source/mwagentspecific/faq/log-rotation-file-handle-cleanup.rst
+++ b/source/mwagentspecific/faq/log-rotation-file-handle-cleanup.rst
@@ -1,64 +1,24 @@
 .. _log-rotation-file-handle-cleanup-mwagent:
 
-Why are Logfiles sometimes not rotated in MonitorWare Agent 14.5 to 15.1?
-==========================================================================
+Why were dynamic log files sometimes not rotated in older MonitorWare Agent versions?
+======================================================================================
 
-This article explains why log files may sometimes not be rotated as expected in MonitorWare Agent versions 14.5 to 15.1, and provides solutions for this issue.
+Older MonitorWare Agent versions could miss some scheduled rotations when
+dynamic filenames were combined with file-handle cleanup. That historical
+behavior affected older releases and was improved in later versions of the
+shared log rotation subsystem.
 
-Background
-----------
+For the guarantees of the current subsystem, including graceful shutdown,
+restart recovery, reload behavior, and dynamic filename support, see
+:doc:`../../shared/faq/log-rotation-guarantees`.
 
-In MonitorWare Agent versions 14.5 to 15.1, there is a feature called "Timeout until unused filehandles are closed" that can interfere with log file rotation under certain circumstances. This feature was improved in later versions to handle rotation more reliably.
+Summary
+-------
 
-The Problem
------------
+In affected older versions, unused dynamic log file handles could already be
+closed when a scheduled rotation time arrived. In that case, the product could
+skip the rotation for that inactive file.
 
-Users may experience inconsistent log file rotation behavior where:
-
-* Some log files rotate successfully every day as scheduled
-* Some log files rotate only partially (not every day)
-* Some log files never rotate at all
-
-This typically occurs when log rotation is scheduled at specific times (e.g., at 0:00 every day) or when using dynamic filenames with property replacer.
-
-Root Cause
-----------
-
-The issue is related to MonitorWare Agent's file handle management feature, which by default:
-
-* Caches file handles internally when dynamic filenames are used to avoid excessive file open/close operations
-* Closes unused file handles after a timeout period if not used anymore
-* Each write to a file resets the timeout counter for that file handle
-
-At the time of scheduled rotation, if a log file has been inactive for an extended period, the cached file handle may be closed. When the rotation process runs, it cannot rotate a file that is no longer actively opened by MonitorWare Agent.
-
-**Note:** This behavior is similar to how your computer closes unused programs to maintain system stability.
-
-Affected Versions
------------------
-
-This issue affects MonitorWare Agent versions 14.5 to 15.1. Later versions include improvements to the file handle management and rotation logic that resolve these limitations.
-
-Solutions
----------
-
-**Recommended Solution: Upgrade MonitorWare Agent**
-
-The most effective solution is to upgrade to MonitorWare Agent version 15.1 or later, where the file handle management and rotation logic have been improved to handle these scenarios properly.
-
-**Alternative Solution: Adjust File Handle Timeout**
-
-If upgrading is not immediately possible:
-
-1. Open the MonitorWare Agent configuration
-2. Navigate to the File Logging action settings
-3. Increase the "Timeout until unused filehandles are closed" setting from the default value
-4. A longer timeout (e.g., 24 hours instead of the default) will reduce the likelihood of missing log rotations
-
-**Important:** The longer timeout interval may increase memory usage, so monitor your system's resource utilization accordingly.
-
-**Additional Recommendations:**
-
-* Review your dynamic filename patterns and property replacer usage
-* Consider the timing of your log rotation schedules
-* Monitor system resources during peak logging periods
+If you are still running one of those older builds, increasing the file handle
+cleanup timeout can reduce the chance of missing a scheduled rotation, but the
+recommended long-term solution is to upgrade to a current release.

--- a/source/shared/faq/log-rotation-guarantees.rst
+++ b/source/shared/faq/log-rotation-guarantees.rst
@@ -1,0 +1,95 @@
+.. include:: ../faq-supporting-labels.rst
+
+.. _log-rotation-guarantees:
+
+What does the current log rotation subsystem guarantee?
+=======================================================
+
+This article summarizes the operational guarantees for the current log rotation
+subsystem used by Adiscon products that write log files through the shared
+Himalaya engine.
+
+Normal operation
+----------------
+
+When log rotation is enabled, the service first detaches the current live log
+file and then continues writing to the normal live file name. The follow-up
+rotation work such as retention renaming, compression, and move-after-rotate is
+handled asynchronously in the background.
+
+This design means that new logging can continue even when post-processing takes
+longer than expected.
+
+Graceful shutdown
+-----------------
+
+Graceful shutdown is still bounded by the existing engine setting
+``nLogRotateWorkerStopWaitTimeout``.
+
+During shutdown the service:
+
+* stops accepting new background rotation work immediately
+* lets existing background workers continue for up to the configured wait time
+* exits when that wait time is reached instead of waiting forever
+
+If a background rotation finishes inside that wait time, it completes normally.
+If it does not finish in time, the unfinished detached work is saved and
+resumed on the next startup.
+
+Restart recovery
+----------------
+
+The service now persists both:
+
+* queued detached rotations that have not started yet
+* detached rotations that were already active in the background worker
+
+On the next startup, that saved work is loaded and resumed before normal new
+runtime traffic begins. This prevents detached rotated files from being lost
+just because service shutdown happened during compression or move-after-rotate.
+
+Configuration reload
+--------------------
+
+Configuration reload does not intentionally tear down the asynchronous log
+rotation subsystem. It keeps ownership of detached rotation work while runtime
+settings are reapplied.
+
+If the current background workers cannot be drained safely inside the bounded
+wait timeout, the service keeps the existing log rotation worker pool instead
+of dropping ownership of detached files during reload.
+
+Dynamic filenames and segments
+------------------------------
+
+Rotation is supported together with dynamic filenames and segmented files. Each
+concrete discovered file is rotated independently, and any unfinished detached
+rotation for that file is recovered on restart in the same way as for
+non-dynamic file names.
+
+Time-of-day rotation after restart
+----------------------------------
+
+This hardening work does not change time-of-day catch-up behavior.
+
+If the service restarts after the configured rotation time for the day, it does
+not automatically create an additional catch-up rotation just because that time
+was missed while the service was stopped.
+
+What this does not mean
+-----------------------
+
+The current guarantee is about bounded graceful shutdown and restart recovery.
+It should not be read as a promise that every single filesystem operation is
+transactional across arbitrary machine crashes or power loss.
+
+Related configuration
+---------------------
+
+The main setting that affects shutdown behavior is:
+
+* ``nLogRotateWorkerStopWaitTimeout``: the maximum time the service waits for
+  background rotation work during graceful shutdown
+
+No additional log rotation shutdown setting is required for the current
+recovery behavior.

--- a/source/shared/index.rst
+++ b/source/shared/index.rst
@@ -25,4 +25,5 @@ independently when needed.
    references/index
    contact-language-policy
    faq/mariadb-odbc-support
+   faq/log-rotation-guarantees
    sales/index

--- a/source/winsyslogspecific/faq/log-rotation-file-handle-cleanup.rst
+++ b/source/winsyslogspecific/faq/log-rotation-file-handle-cleanup.rst
@@ -1,15 +1,24 @@
 .. _log-rotation-file-handle-cleanup-winsyslog:
 
 
-Why are Logfiles sometimes not rotated in WinSyslog 17.5 or lower?
-====================================================================
+Why were dynamic log files sometimes not rotated in older WinSyslog versions?
+=============================================================================
 
-This article explains why log files may sometimes not be rotated as expected in WinSyslog versions 17.5 and earlier, and provides solutions for this issue.
+Older WinSyslog versions could miss some scheduled rotations when dynamic
+filenames were combined with file-handle cleanup. That historical behavior was
+improved in later versions of the shared log rotation subsystem.
+
+For the guarantees of the current subsystem, including graceful shutdown,
+restart recovery, reload behavior, and dynamic filename support, see
+:doc:`../../shared/faq/log-rotation-guarantees`.
 
 Background
 ----------
 
-In WinSyslog versions 17.5 and earlier, there is a feature called "Automatic File Handle Cleanup" that can interfere with log file rotation under certain circumstances. This feature was redesigned in WinSyslog version 18.1 to resolve these issues.
+In older WinSyslog versions, the automatic file handle cleanup logic could
+close an inactive dynamic log file before the scheduled rotation time arrived.
+Later versions improved the shared log rotation subsystem to handle this more
+reliably.
 
 The Problem
 -----------
@@ -57,3 +66,19 @@ If upgrading is not immediately possible:
 4. This adjustment will reduce the likelihood of missing log rotations
 
 **Important:** The longer cleanup interval may increase memory usage, so monitor your system's resource utilization accordingly.
+.. _log-rotation-file-handle-cleanup-winsyslog:
+
+Why were dynamic log files sometimes not rotated in older WinSyslog versions?
+=============================================================================
+
+Older WinSyslog versions could miss some scheduled rotations when dynamic
+filenames were combined with file-handle cleanup. That historical behavior was
+improved in later versions of the shared log rotation subsystem.
+
+For the guarantees of the current subsystem, including graceful shutdown,
+restart recovery, reload behavior, and dynamic filename support, see
+:doc:`../../shared/faq/log-rotation-guarantees`.
+
+If you are still running one of the older affected builds, increasing the file
+handle cleanup timeout can reduce the chance of a missed scheduled rotation,
+but the recommended long-term solution is to upgrade to a current release.


### PR DESCRIPTION
## Summary
Add a shared FAQ page that explains the current log rotation guarantees: bounded graceful shutdown, restart recovery of queued and active detached rotations, reload ownership semantics, dynamic filename and segment behavior, and intentionally unchanged time-of-day restart behavior.

Also update the MWAgent file logging and engine option pages plus the MonitorWare Agent, WinSyslog, and EventReporter log rotation FAQ pages to point at the new guarantee language.

## Notes
- No new user-facing config setting was introduced.
- The main operational setting remains `nLogRotateWorkerStopWaitTimeout`.
- The documentation now describes that shutdown remains bounded and that unfinished detached rotation work is resumed on the next startup.
