### PR TITLE
Fix log rotation documentation settings and rebase onto main

### DIFF
--- a/source/eventreporterspecific/faq/log-rotation-short-delay.rst
+++ b/source/eventreporterspecific/faq/log-rotation-short-delay.rst
@@ -3,25 +3,25 @@
 Why does log rotation fail when using ZIP compression in EventReporter?
 ========================================================================
 
-This article explains why log rotation operations fail when the rotation action delay setting is configured too short, causing ZIP compression to be interrupted by the move operation before completion.
+This article explains why log rotation preparation can time out before the service detaches a file for background compression or move processing.
 
 Problem
 -------
 
-Log rotation operations fail when the rotation action delay setting is configured too short, causing ZIP compression to be interrupted by the move operation before completion.
+Log rotation preparation can fail when the "Maximum wait time for log rotation" setting is too short for the File Action to acquire the rotation mutex while the service is busy.
 
 Symptoms
 --------
 
 * Log files are compressed into ZIP format but remain in the live logging directory
-* Move operations fail after the configured delay period
+* Rotation is skipped or deferred because the rotation preparation mutex could not be acquired in time
 * Incomplete log rotation leaves compressed files in active directories
 * Current day logs may be archived prematurely when using time-based rotation triggers
 
 Root Cause
 ----------
 
-The "Maximum wait time for log rotation" setting in the EventReporter Configuration Client controls the waiting period between when log rotation is triggered and when move operations begin. When this delay is too short (such as the default 15 seconds), ZIP compression processes that take longer than the delay period get interrupted by the move operation, causing the rotation to fail.
+The "Maximum wait time for log rotation" setting in the EventReporter Configuration Client controls how long rotation preparation waits to acquire the File Action rotation mutex. Compression and move operations run afterward as detached background work. When this wait is too short, the file may not be detached for rotation under load.
 
 Solution
 --------
@@ -47,14 +47,14 @@ Option 2: Switch to Size-Based Rotation
 Best Practices
 --------------
 
-* Set rotation action delay to at least 60 seconds when using ZIP compression
+* Set the rotation wait time to at least 60 seconds when the service is busy or storage is slow
 * Consider increasing to 120 seconds for large log files or slow storage systems
 * Use size-based rotation instead of time-based to prevent current-day log pre-archiving
 
 Related Settings
 ----------------
 
-* **Maximum wait time for log rotation**: Controls the delay between rotation trigger and move operations (in milliseconds)
+* **Maximum wait time for log rotation**: Controls how long rotation preparation waits for the File Action rotation mutex (in milliseconds)
 * **Rotation trigger**: Determines when rotation begins (time-based vs size-based)
 * **Compression method**: Affects processing time (ZIP compression takes longer than other methods)
 

--- a/source/mwagentspecific/a-fileoptions.rst
+++ b/source/mwagentspecific/a-fileoptions.rst
@@ -441,10 +441,10 @@ Enable Log Rotation
 ^^^^^^^^^^^^^^^^^^^
 
 **File Configuration field:**
-  nCircularLogging
+  nLogEnableRotate
 
 **Description:**
-  When enabled log files are created and over written in a cycle.
+  Enables the log rotation post-processing subsystem for this File Action.
 
 
 
@@ -463,13 +463,13 @@ Maximum number of rotated log files to keep
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **File Configuration field:**
-  nNumberOfLogfiles
+  nLogRotateMaxFiles
 
 **Description:**
-  Once the last log file is reached, circular logging begins and overwrites the
-  first log file again. If set to 0, log files will not be rotated but can still
-  be processed by Rotate Post Processing (for example compression or backup)
-  along with the Rotate Conditions.
+  Maximum number of rotated log file generations to keep. If set to 0, log
+  files will not be renamed into numbered generations but can still be processed
+  by Rotate Post Processing (for example compression or backup) along with the
+  Rotate Conditions.
 
 
 

--- a/source/mwagentspecific/faq/log-rotation-short-delay.rst
+++ b/source/mwagentspecific/faq/log-rotation-short-delay.rst
@@ -3,25 +3,25 @@
 Why does log rotation fail when using ZIP compression in MonitorWare Agent?
 ============================================================================
 
-This article explains why log rotation operations fail when the rotation action delay setting is configured too short, causing ZIP compression to be interrupted by the move operation before completion.
+This article explains why log rotation preparation can time out before the service detaches a file for background compression or move processing.
 
 Problem
 -------
 
-Log rotation operations fail when the rotation action delay setting is configured too short, causing ZIP compression to be interrupted by the move operation before completion.
+Log rotation preparation can fail when the "Maximum wait time for log rotation" setting is too short for the File Action to acquire the rotation mutex while the service is busy.
 
 Symptoms
 --------
 
 * Log files are compressed into ZIP format but remain in the live logging directory
-* Move operations fail after the configured delay period
+* Rotation is skipped or deferred because the rotation preparation mutex could not be acquired in time
 * Incomplete log rotation leaves compressed files in active directories
 * Current day logs may be archived prematurely when using time-based rotation triggers
 
 Root Cause
 ----------
 
-The "Maximum wait time for log rotation" setting in the MonitorWare Agent Configuration Client controls the waiting period between when log rotation is triggered and when move operations begin. When this delay is too short (such as the default 15 seconds), ZIP compression processes that take longer than the delay period get interrupted by the move operation, causing the rotation to fail.
+The "Maximum wait time for log rotation" setting in the MonitorWare Agent Configuration Client controls how long rotation preparation waits to acquire the File Action rotation mutex. Compression and move operations run afterward as detached background work. When this wait is too short, the file may not be detached for rotation under load.
 
 Solution
 --------
@@ -47,14 +47,14 @@ Option 2: Switch to Size-Based Rotation
 Best Practices
 --------------
 
-* Set rotation action delay to at least 60 seconds when using ZIP compression
+* Set the rotation wait time to at least 60 seconds when the service is busy or storage is slow
 * Consider increasing to 120 seconds for large log files or slow storage systems
 * Use size-based rotation instead of time-based to prevent current-day log pre-archiving
 
 Related Settings
 ----------------
 
-* **Maximum wait time for log rotation**: Controls the delay between rotation trigger and move operations (in milliseconds)
+* **Maximum wait time for log rotation**: Controls how long rotation preparation waits for the File Action rotation mutex (in milliseconds)
 * **Rotation trigger**: Determines when rotation begins (time-based vs size-based)
 * **Compression method**: Affects processing time (ZIP compression takes longer than other methods)
 

--- a/source/shared/spelling-wordlist.txt
+++ b/source/shared/spelling-wordlist.txt
@@ -1109,6 +1109,7 @@ multihome
 multiple-rulesets-rules-actions
 multithread-capable
 multithreaded
+mutex
 mwa-flowchart
 mwa42
 mwagent
@@ -1240,10 +1241,12 @@ nLicenseKey4
 nLicenseKey5
 nListenPort
 nLogDoNotRotateOnShutdown
+nLogEnableRotate
 nLogEnableRotateTimeOfTheDay
 nLogEnableRotateTimeout
 nLogFileType
 nLogMoveAfterRotate
+nLogRotateMaxFiles
 nLogRotateMaxWait
 nLogRotateOnClose
 nLogRotateOnSizeLimit

--- a/source/winsyslogspecific/faq/log-rotation-short-delay.rst
+++ b/source/winsyslogspecific/faq/log-rotation-short-delay.rst
@@ -3,25 +3,25 @@
 Why does log rotation fail when using ZIP compression in WinSyslog?
 ====================================================================
 
-This article explains why log rotation operations fail when the rotation action delay setting is configured too short, causing ZIP compression to be interrupted by the move operation before completion.
+This article explains why log rotation preparation can time out before the service detaches a file for background compression or move processing.
 
 Problem
 -------
 
-Log rotation operations fail when the rotation action delay setting is configured too short, causing ZIP compression to be interrupted by the move operation before completion.
+Log rotation preparation can fail when the "Maximum wait time for log rotation" setting is too short for the File Action to acquire the rotation mutex while the service is busy.
 
 Symptoms
 --------
 
 * Log files are compressed into ZIP format but remain in the live logging directory
-* Move operations fail after the configured delay period
+* Rotation is skipped or deferred because the rotation preparation mutex could not be acquired in time
 * Incomplete log rotation leaves compressed files in active directories
 * Current day logs may be archived prematurely when using time-based rotation triggers
 
 Root Cause
 ----------
 
-The "Maximum wait time for log rotation" setting in the WinSyslog Configuration Client controls the waiting period between when log rotation is triggered and when move operations begin. When this delay is too short (such as the default 15 seconds), ZIP compression processes that take longer than the delay period get interrupted by the move operation, causing the rotation to fail.
+The "Maximum wait time for log rotation" setting in the WinSyslog Configuration Client controls how long rotation preparation waits to acquire the File Action rotation mutex. Compression and move operations run afterward as detached background work. When this wait is too short, the file may not be detached for rotation under load.
 
 Solution
 --------
@@ -47,14 +47,14 @@ Option 2: Switch to Size-Based Rotation
 Best Practices
 --------------
 
-* Set rotation action delay to at least 60 seconds when using ZIP compression
+* Set the rotation wait time to at least 60 seconds when the service is busy or storage is slow
 * Consider increasing to 120 seconds for large log files or slow storage systems
 * Use size-based rotation instead of time-based to prevent current-day log pre-archiving
 
 Related Settings
 ----------------
 
-* **Maximum wait time for log rotation**: Controls the delay between rotation trigger and move operations (in milliseconds)
+* **Maximum wait time for log rotation**: Controls how long rotation preparation waits for the File Action rotation mutex (in milliseconds)
 * **Rotation trigger**: Determines when rotation begins (time-based vs size-based)
 * **Compression method**: Affects processing time (ZIP compression takes longer than other methods)
 


### PR DESCRIPTION
The File Action log rotation registry names were documented as the circular logging fields (`nCircularLogging`, `nNumberOfLogfiles`) instead of the correct async rotation fields. The FAQ pages also mis-described `nLogRotateMaxWait` as a compression/move delay rather than a mutex acquisition timeout.

## Changes

- **`source/mwagentspecific/a-fileoptions.rst`**: Correct "Enable Log Rotation" field name from `nCircularLogging` → `nLogEnableRotate`; correct "Maximum number of rotated log files" from `nNumberOfLogfiles` → `nLogRotateMaxFiles`; update descriptions to match actual semantics
- **`source/*/faq/log-rotation-short-delay.rst`** (mwagent, winsyslog, eventreporter): Reframe `nLogRotateMaxWait` as a rotation mutex wait timeout, not a pre-move delay; update problem description, root cause, and best-practices bullet accordingly