### PR TITLE
[codex] mention Retrospective log viewer

### DIFF
--- a/source/eventreporterspecific/store-and-forward.rst
+++ b/source/eventreporterspecific/store-and-forward.rst
@@ -32,6 +32,15 @@ Common forwarding targets
 - SETP: :doc:`Forward via SETP <../mwagentspecific/a-forwardsetpoptions>`
 - Email: :doc:`Send Email <../mwagentspecific/a-mailoptions>`
 
+Related analysis component
+--------------------------
+
+- For reviewing stored logs later, Adiscon LogAnalyzer works with file- and
+  database-based storage.
+- Users who prefer a simpler standalone tool for direct log file review may
+  also consider the third-party log viewer
+  `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
 Recommended setup path
 ----------------------
 

--- a/source/eventreporterspecific/tutorial-use-with-loganalyzer.rst
+++ b/source/eventreporterspecific/tutorial-use-with-loganalyzer.rst
@@ -55,3 +55,12 @@ LogAnalyzer, continue with:
 
 - :doc:`process-and-filter`
 - :doc:`tutorial-database-logging`
+
+Complementary Tool: Retrospective
+---------------------------------
+
+If you need a simpler way to search and analyze log files directly instead of
+using a web-based database setup, another available option is the third-party
+log viewer `Retrospective <https://www.centeractive.com/products>`_ by
+centeractive. It is suited for direct log file review without requiring a
+central database setup.

--- a/source/introduction/addon-components.rst
+++ b/source/introduction/addon-components.rst
@@ -115,3 +115,19 @@ A special highlighting option assists in reviewing logs. You can define
 rules to highlight any keyword or phrase, associating terms with
 specific colors. This feature proves particularly useful when searching
 for specific errors or other log entries.
+
+Complementary Third-party Tools
+===============================
+
+Adiscon also points users to selected third-party tools that may be useful for
+log analysis and viewing.
+
+Retrospective Log Viewer
+------------------------
+
+In addition to Adiscon LogAnalyzer, users may also consider the third-party log
+viewer `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
+Retrospective is suited for administrators who need to search and analyze large
+volumes of log files across different systems without setting up complex
+indexing or a central database.

--- a/source/mwagentspecific/store-and-forward.rst
+++ b/source/mwagentspecific/store-and-forward.rst
@@ -19,6 +19,15 @@ MonitorWare Agent commonly uses these actions:
 - :doc:`Mail <a-mailoptions>` or :doc:`Start Program <a-startprogram>` for
   alerting and operational response
 
+Related analysis component
+--------------------------
+
+- For reviewing stored logs later, Adiscon LogAnalyzer works with file- and
+  database-based storage.
+- Users who prefer a simpler standalone tool for direct log file review may
+  also consider the third-party log viewer
+  `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
 Database setup paths
 --------------------
 

--- a/source/mwagentspecific/tutorial-use-with-loganalyzer.rst
+++ b/source/mwagentspecific/tutorial-use-with-loganalyzer.rst
@@ -56,3 +56,12 @@ continue with:
 
 - :doc:`process-and-filter`
 - :doc:`tutorial-database-logging`
+
+Complementary Tool: Retrospective
+---------------------------------
+
+If you need a simpler way to search and analyze log files directly instead of
+using a web-based database setup, another available option is the third-party
+log viewer `Retrospective <https://www.centeractive.com/products>`_ by
+centeractive. It is suited for direct log file review without requiring a
+central database setup.

--- a/source/mwagentspecific/understand-the-components.rst
+++ b/source/mwagentspecific/understand-the-components.rst
@@ -46,6 +46,10 @@ Adiscon LogAnalyzer
 supported database. Use it when you need browser-based review and analysis of
 historical events instead of live event viewing.
 
+Users who prefer a simpler standalone tool for direct log file review may also
+consider the third-party log viewer
+`Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
 How They Work Together
 ----------------------
 

--- a/source/rsyslogwaspecific/store-and-forward.rst
+++ b/source/rsyslogwaspecific/store-and-forward.rst
@@ -30,6 +30,15 @@ Common internal actions
 - :doc:`Set Status <../mwagentspecific/a-setstatus>`
 - :doc:`Discard <../mwagentspecific/a-discard>`
 
+Related analysis component
+--------------------------
+
+- For reviewing stored logs later, Adiscon LogAnalyzer works with file- and
+  database-based storage.
+- Users who prefer a simpler standalone tool for direct log file review may
+  also consider the third-party log viewer
+  `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
 Recommended setup path
 ----------------------
 

--- a/source/shared/index.rst
+++ b/source/shared/index.rst
@@ -21,6 +21,7 @@ independently when needed.
    :maxdepth: 2
 
    how-to-integrate-adiscon-windows-products-into-rosi
+   retrospective-log-viewer
    gettingstarted/index
    references/index
    contact-language-policy

--- a/source/shared/retrospective-log-viewer.rst
+++ b/source/shared/retrospective-log-viewer.rst
@@ -1,0 +1,13 @@
+:orphan:
+
+.. _shared-retrospective-log-viewer:
+
+Retrospective Log Viewer
+------------------------
+
+In addition to Adiscon LogAnalyzer, users may also consider the third-party log
+viewer `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
+Retrospective is suited for administrators who need to search and analyze large
+volumes of log files across different systems without setting up complex
+indexing or a central database.

--- a/source/shared/spelling-wordlist.txt
+++ b/source/shared/spelling-wordlist.txt
@@ -440,6 +440,7 @@ Referer
 Remoting
 Replacer
 RestOfMessage
+Retrospective
 Right-click
 Rollout
 Rollouts
@@ -754,6 +755,7 @@ case-sensitive
 categoryid
 catname
 cee
+centeractive
 centralized-monitoring-and-report
 centralized-monitoring-and-reporting
 cfg

--- a/source/shared/tutorials/loganalyzer-setup-and-use.rst
+++ b/source/shared/tutorials/loganalyzer-setup-and-use.rst
@@ -160,3 +160,15 @@ Related information
 
 Use one of the product-specific LogAnalyzer tutorials to prepare the upstream
 data source before configuring LogAnalyzer itself.
+
+Complementary Tool: Retrospective
+---------------------------------
+
+If you prefer a lightweight, standalone Windows application for searching and
+analyzing log files instead of a web-based database solution, another available
+option is the third-party log viewer
+`Retrospective <https://www.centeractive.com/products>`_ by centeractive.
+
+Retrospective is suited for direct log file review, especially when you need to
+search across many distributed log files without any prior indexing or central
+database setup.

--- a/source/winsyslogspecific/producttour/store-and-forward.rst
+++ b/source/winsyslogspecific/producttour/store-and-forward.rst
@@ -38,6 +38,9 @@ Related analysis component
 
 - For reviewing stored logs later, Adiscon LogAnalyzer works with file- and
   database-based storage.
+- Users who prefer a simpler standalone tool for direct log file review may
+  also consider the third-party log viewer
+  `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
 
 Recommended setup path
 ----------------------

--- a/source/winsyslogspecific/producttour/understand-the-components.rst
+++ b/source/winsyslogspecific/producttour/understand-the-components.rst
@@ -30,7 +30,9 @@ The four components
 4. **Adiscon LogAnalyzer**
    This is an optional analysis component for working with stored logs,
    especially in files or databases. It is for browsing and reviewing retained
-   data, not for live message intake.
+   data, not for live message intake. Users who prefer a simpler standalone
+   tool for direct log file review may also consider the third-party log viewer
+   `Retrospective <https://www.centeractive.com/products>`_ by centeractive.
 
 How they fit together
 ---------------------

--- a/source/winsyslogspecific/tutorial-use-with-loganalyzer.rst
+++ b/source/winsyslogspecific/tutorial-use-with-loganalyzer.rst
@@ -55,3 +55,12 @@ LogAnalyzer, continue with:
 
 - :doc:`producttour/process-and-filter`
 - :doc:`tutorial-database-logging`
+
+Complementary Tool: Retrospective
+---------------------------------
+
+If you need a simpler way to search and analyze log files directly instead of
+using a web-based database setup, another available option is the third-party
+log viewer `Retrospective <https://www.centeractive.com/products>`_ by
+centeractive. It is suited for direct log file review without requiring a
+central database setup.


### PR DESCRIPTION
Adds neutral documentation mentions for Centeractive Retrospective as an optional third-party log viewer alternative, based on the prior prototype but with softer non-promotional wording. Includes a shared Retrospective page, product tutorial/store-and-forward mentions, shared navigation, and spelling word-list entries. Validation passed: make all-html SPHINXOPTS=-W; make validate-rst PYTHON=venv/bin/python; make spelling.