### PR TITLE
docs: clarify licensing and version wording

### DIFF
--- a/source/eventreporterspecific/commandlineswitches.rst
+++ b/source/eventreporterspecific/commandlineswitches.rst
@@ -28,18 +28,19 @@ The ``-v`` switch gives you information about the version of the service.
 - ``evntslog.exe -i CustomServiceName``
 - ``evntslog.exe -u CustomServiceName``
 
-You can import Adiscon Config Format (cfg) configuration files via the
-command line as well. The syntax is quite easy. Simply execute the
-EventReporter configuration client and append the name of the configuration
-file.
+You can import configuration files via the command line as well. Use YAML
+(``.yaml``) for new imports. The legacy Adiscon Config Format (``.cfg``) remains
+supported for compatibility with existing files and support workflows. The
+syntax is quite easy: execute the EventReporter configuration client and append
+the name of the configuration file.
 
 **Sample:**
 
-CFGEvntSLog.exe example.cfg
+CFGEvntSLog.exe example.yaml
 
 or
 
-CFGEvntSLog.exe "example.cfg"
+CFGEvntSLog.exe "example.yaml"
 
 After this is executed, you will see the splash screen of the configuration
 client and then the import dialogue, which you have to confirm manually.
@@ -47,4 +48,4 @@ client and then the import dialogue, which you have to confirm manually.
 For doing a silent import, the ``/f`` parameter has to be appended. This will
 look like this:
 
-``CFGEvntSLog.exe "example.cfg" /f``
+``CFGEvntSLog.exe "example.yaml" /f``

--- a/source/eventreporterspecific/configuringeventreporter.rst
+++ b/source/eventreporterspecific/configuringeventreporter.rst
@@ -57,9 +57,9 @@ service. Within the ruleset:
 
 The following sections describe the detailed properties of each element.
 
-Configuration client changes in 26.07
--------------------------------------
+User Interface changes in 26.07
+-------------------------------
 
-See :doc:`../shared/references/configuration-client-2026` for license file UI,
-YAML import/export, service toolbar changes, and the next-generation client
-preview.
+See :doc:`../shared/references/user-interface-changes` for license file UI,
+YAML import/export, service toolbar changes, and the EventReporter User
+Interface.

--- a/source/eventreporterspecific/faq.rst
+++ b/source/eventreporterspecific/faq.rst
@@ -46,7 +46,7 @@ Licensing and purchasing
    faq/enter-license-information
    ../shared/faq/version-numbering-change
    ../shared/faq/unsupported-configuration-blocks
-   ../shared/faq/netsend-removed-2026
+   ../shared/faq/netsend-removed-from-client
    ../shared/faq/rest-output-getting-started
 
 Platform and compatibility

--- a/source/eventreporterspecific/faq/eventreporter-iot2025-support.rst
+++ b/source/eventreporterspecific/faq/eventreporter-iot2025-support.rst
@@ -50,7 +50,7 @@ Recommended workflow:
 
 2. Transfer the configuration to Server Core
 
-   - Copy the exported ``.cfg`` file to the Server Core system (e.g., via
+   - Copy the exported ``.yaml`` file to the Server Core system (e.g., via
      PowerShell Remoting or SMB)
 
 3. Enable File Config Mode and set paths via registry

--- a/source/eventreporterspecific/installation.rst
+++ b/source/eventreporterspecific/installation.rst
@@ -40,7 +40,7 @@ Installation steps
 3. Select the components you want to install.
 
    - The **EventReporter Service** is the runtime component.
-   - The **EventReporter Configuration Client** is the administrative UI.
+   - The **EventReporter Configuration Client** is the administrative tool.
 
 4. Finish the installer.
 5. Start the EventReporter Configuration Client.

--- a/source/eventreporterspecific/references.rst
+++ b/source/eventreporterspecific/references.rst
@@ -31,7 +31,7 @@ Technical lookup material
    ../shared/references/complexfilterconditions
    ../shared/references/connecttocomputer
    ../shared/references/microsoftsystemerrorcodes
-   ../shared/references/configuration-client-2026
+   ../shared/references/user-interface-changes
    glossary
 
 External reference

--- a/source/eventreporterspecific/understand-the-components.rst
+++ b/source/eventreporterspecific/understand-the-components.rst
@@ -14,7 +14,7 @@ The two main components
    service, runs the configured input services, evaluates rules, and then
    stores or forwards matching events.
 2. **EventReporter Configuration Client**
-   This is the administrative user interface. You use it to define input
+   This is the administrative tool. You use it to define input
    services, rulesets, filters, and actions. Changes are made in the
    Configuration Client and then applied so the running EventReporter service
    can use the new configuration.

--- a/source/mwagentspecific/clienttools.rst
+++ b/source/mwagentspecific/clienttools.rst
@@ -20,9 +20,9 @@ and **Open Windows Services** are on the main window toolbar only.
 .. image:: ../images/service-toolbar-2026.png
    :width: 100%
 
-See :doc:`../shared/references/configuration-client-2026` for **Reset to
+See :doc:`../shared/references/user-interface-changes` for **Reset to
 default** (selected item vs entire configuration), YAML import/export, and the
-next-generation client preview.
+MonitorWare Agent User Interface.
 
 
 Syslog Test Message

--- a/source/mwagentspecific/configuringmwagent.rst
+++ b/source/mwagentspecific/configuringmwagent.rst
@@ -10,9 +10,9 @@ Configuration is created in the **MonitorWare Agent Configuration Client** and
 then applied to the **MonitorWare Agent Service**. Save and apply changes after
 editing so the running service uses the updated configuration.
 
-For configuration client changes introduced with **26.07** (license file UI,
-YAML, service toolbar, WinUI preview), see
-:doc:`../shared/references/configuration-client-2026`.
+For User Interface changes introduced with **26.07** (license file UI, YAML,
+service toolbar, and the MonitorWare Agent User Interface), see
+:doc:`../shared/references/user-interface-changes`.
 
 In this manual, **input** is the clearest plain-language concept for anything
 that collects or receives data, while **service** remains the operational term

--- a/source/mwagentspecific/faq.rst
+++ b/source/mwagentspecific/faq.rst
@@ -14,7 +14,7 @@ Deployment and licensing
    faq/printable-manual
    ../shared/faq/version-numbering-change
    ../shared/faq/unsupported-configuration-blocks
-   ../shared/faq/netsend-removed-2026
+   ../shared/faq/netsend-removed-from-client
    ../shared/faq/rest-output-getting-started
    ../shared/faq/remote-administration-and-browser-based-review
    faq/repeatable-deployment

--- a/source/mwagentspecific/faq/mwagent-iot2025-support.rst
+++ b/source/mwagentspecific/faq/mwagent-iot2025-support.rst
@@ -50,7 +50,7 @@ Recommended workflow:
 
 2. Transfer the configuration to Server Core
 
-   - Copy the exported ``.cfg`` file to the Server Core system (e.g., via
+   - Copy the exported ``.yaml`` file to the Server Core system (e.g., via
      PowerShell Remoting or SMB)
 
 3. Enable File Config Mode and set paths via registry

--- a/source/mwagentspecific/references.rst
+++ b/source/mwagentspecific/references.rst
@@ -14,7 +14,7 @@ Product controls and local operation
 
    ../shared/references/commandlineswitches
    ../shared/references/mwagentshortcutkeys
-   ../shared/references/configuration-client-2026
+   ../shared/references/user-interface-changes
 
 Technical lookup material
 -------------------------

--- a/source/rsyslogwaspecific/commandlineswitches.rst
+++ b/source/rsyslogwaspecific/commandlineswitches.rst
@@ -29,18 +29,19 @@ The ``-v`` switch gives you information about the version of the service.
 - ``rsyslogd.exe -i CustomServiceName``
 - ``rsyslogd.exe -u CustomServiceName``
 
-You can import Adiscon Config Format (cfg) configuration files via the
-command line as well. The syntax is quite easy. Simply execute the rsyslog
-Windows Agent configuration client and append the name of the configuration
-file.
+You can import configuration files via the command line as well. Use YAML
+(``.yaml``) for new imports. The legacy Adiscon Config Format (``.cfg``) remains
+supported for compatibility with existing files and support workflows. The
+syntax is quite easy: execute the rsyslog Windows Agent configuration client and
+append the name of the configuration file.
 
 **Sample:**
 
-RsyslogConfigClient.exe example.cfg
+RsyslogConfigClient.exe example.yaml
 
 or
 
-RsyslogConfigClient.exe "example.cfg"
+RsyslogConfigClient.exe "example.yaml"
 
 After this is executed, you will see the splash screen of the configuration
 client and then the import dialogue, which you have to confirm manually.
@@ -48,4 +49,4 @@ client and then the import dialogue, which you have to confirm manually.
 For doing a silent import, the ``/f`` parameter has to be appended. This will
 look like this:
 
-``RsyslogConfigClient.exe "example.cfg" /f``
+``RsyslogConfigClient.exe "example.yaml" /f``

--- a/source/rsyslogwaspecific/configuringrsyslogwa.rst
+++ b/source/rsyslogwaspecific/configuringrsyslogwa.rst
@@ -10,7 +10,7 @@ How configuration works
 -----------------------
 
 The rsyslog Windows Agent service runs in the background once it is installed
-and configured. The Configuration Client is the administrative UI used to define
+and configured. The Configuration Client is the administrative tool used to define
 services, rulesets, filters, and actions.
 
 Changes are made in the Configuration Client and then applied so the running
@@ -56,7 +56,7 @@ Common editing tasks
 What to read next
 -----------------
 
-- :doc:`../shared/references/configuration-client-2026`
+- :doc:`../shared/references/user-interface-changes`
 - :doc:`core-concepts`
 - :doc:`services`
 - :doc:`filterconditions`

--- a/source/rsyslogwaspecific/references.rst
+++ b/source/rsyslogwaspecific/references.rst
@@ -30,7 +30,7 @@ Technical lookup material
    ../shared/references/complexfilterconditions
    ../shared/references/connecttocomputer
    ../shared/references/microsoftsystemerrorcodes
-   ../shared/references/configuration-client-2026
+   ../shared/references/user-interface-changes
    glossaryofterms
 
 External reference

--- a/source/rsyslogwaspecific/understand-the-components.rst
+++ b/source/rsyslogwaspecific/understand-the-components.rst
@@ -14,7 +14,7 @@ The two main components
    service, runs the configured input services, evaluates rules, and forwards
    matching data.
 2. **rsyslog Windows Agent Configuration Client**
-   This is the administrative user interface. You use it to define input
+   This is the administrative tool. You use it to define input
    services, rulesets, filters, and actions. Changes are made in the
    Configuration Client and then applied so the running service can use the new
    configuration.

--- a/source/shared/faq/high-load-performance-worker-threads.rst
+++ b/source/shared/faq/high-load-performance-worker-threads.rst
@@ -51,7 +51,7 @@ The most important setting for high-load systems is the Worker Threads configura
 
 **For WinSyslog:**
 
-1. Open WinSyslog Config Client
+1. Open the WinSyslog Configuration Client
 2. Navigate to **General Options > Queue Manager** section
 3. Set **Number of worker threads** to at least **half the CPU core count**
 
@@ -65,7 +65,7 @@ The most important setting for high-load systems is the Worker Threads configura
 
 **For MonitorWare Agent:**
 
-1. Open MonitorWare Agent Config Client
+1. Open the MonitorWare Agent Configuration Client
 2. Navigate to **General Options > Queue Manager** section
 3. Set **Number of worker threads** to at least **half the CPU core count**
 
@@ -109,7 +109,8 @@ For busy production systems, avoid making large configuration changes directly:
 2. Verify the changes work correctly on the test system
 3. Import the verified configuration into the production system
 4. If automatic configuration reload is enabled, the service will reload automatically after saving
-5. If automatic configuration reload is disabled, manually restart the service (from Config Client or Windows Services Management Console)
+5. If automatic configuration reload is disabled, manually restart the service
+   from the Configuration Client or Windows Services Management Console
 6. Monitor system performance after the change
 
 **Use Windows Services Management Console for Service Operations**

--- a/source/shared/faq/netsend-removed-from-client.rst
+++ b/source/shared/faq/netsend-removed-from-client.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. _netsend-removed-2026:
+.. _netsend-removed-from-client:
 
 Why is Net Send no longer available in the configuration client?
 ================================================================

--- a/source/shared/gettingstarted/exportsettings.rst
+++ b/source/shared/gettingstarted/exportsettings.rst
@@ -27,39 +27,43 @@ Here you can export/import the configuration in different formats.
 Registry Textfile (32 Bit Windows) / Registry Textfile (64 Bit Windows)
 -----------------------------------------------------------------------
 
-  Use this option if you want to transfer the settings via a registry file.
-  Depending on your Windows system, choose Registry Textfile (32 Bit Windows) or
-  Registry Textfile (64 Bit Windows).
+  This option is available for older workflows that require direct Windows
+  Registry transfer. For support, backup, or moving a configuration between
+  systems, prefer **Adiscon YAML Config Format**.
 
-These can be imported by double-clicking on the desktop, regedit.exe will be
-automatically called.
+  If you intentionally need a registry file, choose the 32-bit or 64-bit
+  registry text file option that matches your Windows system.
 
-Adiscon Config Format
----------------------
+Registry files can be imported by double-clicking them. Windows starts Registry
+Editor (``regedit.exe``) and writes the settings directly into the Windows
+Registry.
+
+Adiscon YAML Config Format
+--------------------------
 
 When working on a support incident, it is often extremely helpful to re-create a
 customer environment in the Adiscon lab. To aid in this process, we have added
 functionality to export an exact snapshot of a configuration. There are multiple
-methods available. Adiscon Support prefers Adiscon Config Format. Please note
-that when we have received your file, we are also able to make adjustments (if
-needed) and provide those back to you. This is a very helpful support tool.
+methods available. Adiscon Support prefers YAML configuration files because they
+are readable and can be re-imported for analysis. Please note that when we have
+received your file, we are also able to make adjustments (if needed) and provide
+those back to you. This is a very helpful support tool.
 
 
 To use it, please do the following:
 
   1. Go to "File -> Export Configuration"
 
-  2. Choose "Adiscon Config Format".
+  2. Choose "Adiscon YAML Config Format".
 
   3. Save the configuration file.
 
 
 
-You may be reluctant to send the registry file because of security reasons. We
-recommend you to review the contents of the registry file for security purposes
-with a notepad or any other text editor.
+You may be reluctant to send the exported file because of security reasons. We
+recommend that you review the contents of the file with Notepad or another text
+editor before sending it.
 
-**Please Note:** We have a 10 MB limit on our mail account. Please zip the registry
-
-file and then send it to us. If the file size doesn't reduce after compressing
-it you should contact Adiscon Support for further instructions.
+**Please Note:** We have a 10 MB limit on our mail account. Please zip the
+exported file and then send it to us. If the file size doesn't reduce after
+compressing it you should contact Adiscon Support for further instructions.

--- a/source/shared/references/commandlineswitches.rst
+++ b/source/shared/references/commandlineswitches.rst
@@ -38,18 +38,19 @@ The ``-v`` switch gives you information about the version of the service.
 - ``mwagent.exe -u CustomServiceName``
 
 
-You can import Adiscon Config Format (cfg) configuration files via the
-command line as well. The syntax is quite easy. Simply execute the
-MonitorWare Agent configuration client and append the name of the
-configuration file.
+You can import configuration files via the command line as well. Use YAML
+(``.yaml``) for new imports. The legacy Adiscon Config Format (``.cfg``) remains
+supported for compatibility with existing files and support workflows. The
+syntax is quite easy: execute the MonitorWare Agent configuration client and
+append the name of the configuration file.
 
 **Sample:**
 
-mwclient.exe example.cfg
+mwclient.exe example.yaml
 
 or
 
-mwclient.exe "example.cfg"
+mwclient.exe "example.yaml"
 
 After this is executed, you will see the splash screen of the configuration
 client and then the import dialogue, which you have to confirm manually.
@@ -57,4 +58,4 @@ client and then the import dialogue, which you have to confirm manually.
 For doing a silent import, the ``/f`` parameter has to be appended.
 This will look like this:
 
-``mwclient.exe "example.cfg" /f``
+``mwclient.exe "example.yaml" /f``

--- a/source/shared/references/index.rst
+++ b/source/shared/references/index.rst
@@ -32,7 +32,7 @@ Manual:
    mwagentshortcutkeys
    registrypaths
    editioncomparison
-   configuration-client-2026
+   user-interface-changes
    microsoftsystemerrorcodes
 
 

--- a/source/shared/references/user-interface-changes.rst
+++ b/source/shared/references/user-interface-changes.rst
@@ -1,20 +1,23 @@
 :orphan:
 
-.. _configuration-client-2026:
+.. _user-interface-changes:
 
-Configuration client changes in 26.07
-=====================================
+User Interface changes
+======================
 
-The **26.07** installer ships two configuration clients:
+The **26.07** installer includes the established configuration client and the
+new product-specific User Interface:
 
-- **Established configuration client** — the WinForms client documented in this
-  manual (primary reference for setup steps and screenshots).
-- **Next-generation Configuration Client Preview** — a WinUI-based workbench
-  (``adiscon-client-ng``), shipped as a **preview** alongside the classic client.
+- **Established configuration client** - the WinForms client documented in this
+  manual and the primary reference for setup steps and screenshots.
+- **Product User Interface** - the newer WinUI-based interface
+  (``adiscon-client-ng``), such as the WinSyslog User Interface or
+  EventReporter User Interface, available alongside the established
+  configuration client.
 
-The preview is optional. The classic client supports license file application
-and full configuration editing. See your product website's **Upgrade** article
-for the customer-facing preview description.
+The established configuration client supports license file application and full
+configuration editing. See your product website's **Upgrade** article for the
+customer-facing description of the Product User Interface.
 
 Property window toolbar
 -----------------------
@@ -64,8 +67,8 @@ The **File** menu supports:
 .. image:: ../../images/file-menu-yaml.png
    :width: 100%
 
-- **Adiscon YAML Config Format** (``.yaml``) — import and export
-- **Adiscon Legacy Format** (``.cfg``) — legacy text configuration
+- **Adiscon YAML Config Format** (``.yaml``) - import and export
+- **Adiscon Legacy Format** (``.cfg``) - legacy text configuration
 
 See the file-based configuration chapter in your product manual and
 :ref:`unsupported-configuration-blocks`.

--- a/source/winsyslogspecific/commandlineswitches.rst
+++ b/source/winsyslogspecific/commandlineswitches.rst
@@ -28,17 +28,19 @@ The ``-v`` switch gives you information about the version of the service.
 - ``WINSyslog.exe -i CustomServiceName``
 - ``WINSyslog.exe -u CustomServiceName``
 
-You can import Adiscon Config Format (cfg) configuration files via the
-command line as well. The syntax is quite easy. Simply execute the WinSyslog
-configuration client and append the name of the configuration file.
+You can import configuration files via the command line as well. Use YAML
+(``.yaml``) for new imports. The legacy Adiscon Config Format (``.cfg``) remains
+supported for compatibility with existing files and support workflows. The
+syntax is quite easy: execute the WinSyslog configuration client and append the
+name of the configuration file.
 
 **Sample:**
 
-WINSyslogClient.exe example.cfg
+WINSyslogClient.exe example.yaml
 
 or
 
-WINSyslogClient.exe "example.cfg"
+WINSyslogClient.exe "example.yaml"
 
 After this is executed, you will see the splash screen of the configuration
 client and then the import dialogue, which you have to confirm manually.
@@ -46,4 +48,4 @@ client and then the import dialogue, which you have to confirm manually.
 For doing a silent import, the ``/f`` parameter has to be appended. This will
 look like this:
 
-``WINSyslogClient.exe "example.cfg" /f``
+``WINSyslogClient.exe "example.yaml" /f``

--- a/source/winsyslogspecific/components.rst
+++ b/source/winsyslogspecific/components.rst
@@ -15,7 +15,7 @@ For the canonical component overview, use
 That page explains:
 
 - the WinSyslog Service as the core runtime component
-- the Configuration Client as the administrative UI
+- the Configuration Client as the administrative tool
 - the Interactive Syslog Viewer as the live-view component
 - Adiscon LogAnalyzer as the stored-log analysis component
 

--- a/source/winsyslogspecific/configuringwinsyslog-j.rst
+++ b/source/winsyslogspecific/configuringwinsyslog-j.rst
@@ -7,7 +7,7 @@ In this chapter, you will learn how to configure WinSyslog.
 
 The WinSyslog runtime service runs in the background once it is configured.
 There is no manual intervention needed to operate it. As such, this chapter
-focuses on the WinSyslog configuration Client application. It is used to
+focuses on the WinSyslog Configuration Client application. It is used to
 configure input services, rulesets, actions, and related settings.
 
 To run the WinSyslog Configuration Client, simply click its icon present in the
@@ -21,7 +21,7 @@ similar to the following one appears:
 * Configuration Client*
 
 
-The configuration Client ("the Client") has two elements. On the left hand side
+The Configuration Client ("the Client") has two elements. On the left hand side
 is a tree view that allows you to select the various elements of the WinSyslog
 system. On the right hand side are parameters specific to the element selected
 in the tree view. In the sample above, the right hand side displays the
@@ -103,9 +103,8 @@ associated with. Finally, beneath actions are all actions to carry out.
 
 The following sections describe each element's properties.
 
-Configuration client changes in 26.07
--------------------------------------
+User Interface changes in 26.07
+-------------------------------
 
-See :doc:`../shared/references/configuration-client-2026` for license file UI,
-YAML import/export, service toolbar changes, and the next-generation client
-preview.
+See :doc:`../shared/references/user-interface-changes` for license file UI,
+YAML import/export, service toolbar changes, and the WinSyslog User Interface.

--- a/source/winsyslogspecific/configuringwinsyslog.rst
+++ b/source/winsyslogspecific/configuringwinsyslog.rst
@@ -21,7 +21,7 @@ similar to the following one appears:
 * Configuration Client*
 
 
-The configuration Client ("the Client") has two elements. On the left-hand side
+The Configuration Client ("the Client") has two elements. On the left-hand side
 is a tree view that allows you to select the various elements of the WinSyslog
 system. On the right-hand side are parameters specific to the element selected
 in the tree view. In the sample above, the right-hand side displays the
@@ -104,9 +104,8 @@ associated with. Finally, beneath actions are all actions to carry out.
 
 The following sections describe each element's properties.
 
-Configuration client changes in 26.07
--------------------------------------
+User Interface changes in 26.07
+-------------------------------
 
-See :doc:`../shared/references/configuration-client-2026` for license file UI,
-YAML import/export, service toolbar changes, and the next-generation client
-preview.
+See :doc:`../shared/references/user-interface-changes` for license file UI,
+YAML import/export, service toolbar changes, and the WinSyslog User Interface.

--- a/source/winsyslogspecific/faq.rst
+++ b/source/winsyslogspecific/faq.rst
@@ -67,7 +67,7 @@ Licensing and product positioning
    faq/winsyslog-vs-kiwi-syslog-server
    ../shared/faq/version-numbering-change
    ../shared/faq/unsupported-configuration-blocks
-   ../shared/faq/netsend-removed-2026
+   ../shared/faq/netsend-removed-from-client
    ../shared/faq/rest-output-getting-started
 
 Platform and compatibility

--- a/source/winsyslogspecific/faq/winsyslog-iot2025-support.rst
+++ b/source/winsyslogspecific/faq/winsyslog-iot2025-support.rst
@@ -47,7 +47,7 @@ Recommended workflow:
 
 2. Transfer the configuration to Server Core
 
-   - Copy the exported ``.cfg`` file to the Server Core system (e.g., via
+   - Copy the exported ``.yaml`` file to the Server Core system (e.g., via
      PowerShell Remoting or SMB)
 
 3. Enable File Config Mode and set paths via registry

--- a/source/winsyslogspecific/producttour/understand-the-components.rst
+++ b/source/winsyslogspecific/producttour/understand-the-components.rst
@@ -19,7 +19,7 @@ The four components
    service, receives log data through configured input services, processes it
    through rulesets and actions, and stores or forwards the results.
 2. **WinSyslog Configuration Client**
-   This is the administrative user interface. You use it to configure input
+   This is the administrative tool. You use it to configure input
    services, rulesets, filters, and actions. Changes are made in the
    Configuration Client and then applied to the WinSyslog service. It is also
    where you send a test syslog message from the ``Tools`` menu.

--- a/source/winsyslogspecific/references.rst
+++ b/source/winsyslogspecific/references.rst
@@ -37,7 +37,7 @@ troubleshooting.
    ../shared/references/connecttocomputer
    ../shared/references/registrypaths
    ../shared/references/microsoftsystemerrorcodes
-   ../shared/references/configuration-client-2026
+   ../shared/references/user-interface-changes
    glossaryofterms
 
 External reference


### PR DESCRIPTION
﻿## Summary
- clarify licensing docs around current license files and older license-key workflows
- simplify version wording and move version-numbering context into a focused FAQ
- make YAML the recommended configuration export/import format, with legacy `.cfg` documented as compatibility fallback
- add agent anti-pattern guidance to prevent reintroducing internal licensing/version terminology

## Validation
- `make validate-rst PYTHON=python`
- `make spelling`
- `make clean; make -j7 all-html SPHINXOPTS="-W"`

## Notes
- Old fresh documentation URLs for `license-v2`, version-numbering references, and `*-2026` helper pages were intentionally removed or renamed as part of the cleanup.
