### PR TITLE
docs: align product capability documentation

### DIFF
--- a/rsyslog/conf.py
+++ b/rsyslog/conf.py
@@ -111,7 +111,7 @@ exclude_patterns = ['index.eventreporter.rst','index.mwagent.rst','index.winsysl
     'mwagentspecific/a-forwardsetpoptions.rst','mwagentspecific/a-forwardsyslogoptions.rst',
     'mwagentspecific/a-httprequest.rst','mwagentspecific/a-restoutput.rst','mwagentspecific/a-mailoptions.rst',
     'mwagentspecific/a-netsend.rst','mwagentspecific/a-oledbdatabaseaction.rst','mwagentspecific/a-playsound.rst',
-    'mwagentspecific/a-postprocessevent.rst','mwagentspecific/a-resolvehostname.rst','mwagentspecific/a-sendmsqueue.rst',
+    'mwagentspecific/a-postprocessevent.rst','mwagentspecific/a-sendmsqueue.rst',
     'mwagentspecific/a-sendsnmptrap.rst','mwagentspecific/a-sendtocommunicationsport.rst','mwagentspecific/a-startprogram.rst',
     'mwagentspecific/a-syslogqueueaction.rst','mwagentspecific/cpumonitor.rst','mwagentspecific/databasemonitor.rst',
     'mwagentspecific/diskspacemonitor.rst','mwagentspecific/f-cpumemorymonitor.rst','mwagentspecific/f-diskspacemonitor.rst',

--- a/source/mwagentspecific/a-forwardsetpoptions.rst
+++ b/source/mwagentspecific/a-forwardsetpoptions.rst
@@ -3,6 +3,11 @@ Send SETP
 
 With the "Send SETP" action, messages can be sent to a SETP server.
 
+.. only:: winsyslog or winsyslog_j
+
+   In WinSyslog, the **Send SETP** action is a sender-side action. Receiving
+   SETP events requires the separate ``SETP Server`` service.
+
 
 .. image:: ../images/a-forwardsetp-general.png
    :width: 100%

--- a/source/mwagentspecific/a-httprequest.rst
+++ b/source/mwagentspecific/a-httprequest.rst
@@ -5,6 +5,10 @@ The **HTTP Request** action sends an HTTP or HTTPS request to a remote host.
 It is listed under **Forwarding** in the configuration client. Use it for
 simple HTTP callbacks where the **HTTP REST Output** action is not required.
 
+.. only:: eventreporter
+
+   In EventReporter, **HTTP Request** is available in Professional and above.
+
 .. image:: ../images/a-httprequest.png
    :width: 100%
 

--- a/source/mwagentspecific/a-resolvehostname.rst
+++ b/source/mwagentspecific/a-resolvehostname.rst
@@ -1,9 +1,9 @@
 Resolve Hostname Action
 =======================
 
-Many Customers asked for resolve hostname options in different services. This
-feature has now been implemented as an action. An action can be used with
-every service, and it does not delay the work of a service.
+The **Resolve Hostname** action resolves a host name or address from one event
+property and stores the result in another property. Because it is an action,
+you can place it in the ruleset where the resolved value is needed.
 
 
 .. image:: ../images/a-resolvehostname.png

--- a/source/mwagentspecific/a-senddtls.rst
+++ b/source/mwagentspecific/a-senddtls.rst
@@ -1,7 +1,9 @@
 Send DTLS
 =========
 
-This action sends messages securely using the Datagram Transport Layer Security (DTLS) protocol. It ensures message confidentiality and integrity over an encrypted channel. The implementation uses OpenSSL to handle encryption and decryption, ensuring robust security and compatibility with industry standards. DTLS is suitable for applications requiring low latency and secure communication.
+This action sends messages securely using Datagram Transport Layer Security
+(DTLS). Use it when the receiving system expects DTLS transport for forwarded
+messages.
 
 .. image:: ../images/send-dtls-configuration.png
    :width: 100%

--- a/source/rsyslogwaspecific/actions.rst
+++ b/source/rsyslogwaspecific/actions.rst
@@ -27,5 +27,6 @@ Internal actions
    ../mwagentspecific/a-computestatusvariable
    ../mwagentspecific/a-discard
    ../mwagentspecific/a-normalizeevent
+   ../mwagentspecific/a-resolvehostname
    ../mwagentspecific/a-setproperty
    ../mwagentspecific/a-setstatus

--- a/source/rsyslogwaspecific/rswaconcepts-actions.rst
+++ b/source/rsyslogwaspecific/rswaconcepts-actions.rst
@@ -19,6 +19,8 @@ Internal actions modify or redirect processing inside the agent itself:
 
 - **Call RuleSet** transfers processing to another ruleset
 - **Normalize Event** rewrites selected event content
+- **Resolve Hostname** resolves a name or address from one property and stores
+  the result in another property
 - **Set Property** and **Set Status** add or modify internal values
 - **Discard** stops further processing for the current event
 

--- a/source/rsyslogwaspecific/store-and-forward.rst
+++ b/source/rsyslogwaspecific/store-and-forward.rst
@@ -26,6 +26,7 @@ Common internal actions
 
 - :doc:`Call RuleSet <../mwagentspecific/a-callruleset>`
 - :doc:`Normalize Event <../mwagentspecific/a-normalizeevent>`
+- :doc:`Resolve Hostname <../mwagentspecific/a-resolvehostname>`
 - :doc:`Set Property <../mwagentspecific/a-setproperty>`
 - :doc:`Set Status <../mwagentspecific/a-setstatus>`
 - :doc:`Discard <../mwagentspecific/a-discard>`

--- a/source/shared/references/comparisonofproperties.rst
+++ b/source/shared/references/comparisonofproperties.rst
@@ -7,30 +7,34 @@ Comparison of properties
 
 **Available in MonitorWare Agent, EventReporter and WinSyslog**
 
-The property replacer is a reference - the actual properties are very depending
-on the edition purchased. We have just included information on what is
-available in which products for your ease and convenience.
-
+The property replacer is a reference. The actual properties available for an
+event depend on the product, the configured service, and in some cases the
+edition. For WinSyslog, Windows Event Log properties are available when the
+event is received through SETP from another Adiscon product.
 
 .. code-block:: text
 
-  Properties Available  MonitorWareAgent  WinSyslog  EventReporter
+  Properties Available  MonitorWare Agent  WinSyslog  EventReporter
 
-  Standard Property            Yes           Yes         Yes
-  Windows Event Log            Yes                       Yes
-  Syslog Message               Yes           Yes
+  Standard Property            Yes             Yes        Yes
+  Windows Event Log            Yes             SETP       Yes
+  Syslog Message               Yes             Yes
   Disk Space Monitor           Yes
   File Monitor                 Yes
-  Windows Service Monitor      Yes                       Yes
+  Windows Service Monitor      Yes                        Yes
   Ping Probe                   Yes
   Port Probe                   Yes
   Database Monitor             Yes
   Serial Port Monitor          Yes
   MonitorWare Echo Request     Yes
-  System                       Yes          Yes          Yes
-  Custom                       Yes          Yes          Yes
+  System                       Yes             Yes        Yes
+  Custom                       Yes             Yes        Yes
   NNTP Probe                   Yes
   HTTP Probe                   Yes
   FTP Probe                    Yes
   SMTP Probe                   Yes
   POP3 Probe                   Yes
+
+``SETP`` means that WinSyslog can use those properties when they are
+transported through SETP; it does not mean that WinSyslog collects Windows
+Event Logs locally.

--- a/source/shared/references/user-interface-changes.rst
+++ b/source/shared/references/user-interface-changes.rst
@@ -6,18 +6,38 @@ User Interface changes
 ======================
 
 The **26.07** installer includes the established configuration client and the
-new product-specific User Interface:
+new user interface for this product:
 
 - **Established configuration client** - the WinForms client documented in this
   manual and the primary reference for setup steps and screenshots.
-- **Product User Interface** - the newer WinUI-based interface
-  (``adiscon-client-ng``), such as the WinSyslog User Interface or
-  EventReporter User Interface, available alongside the established
-  configuration client.
+
+.. only:: winsyslog or winsyslog_j
+
+   - **WinSyslog User Interface** - the newer WinUI-based interface
+     (``adiscon-client-ng``) available alongside the established configuration
+     client.
+
+.. only:: eventreporter
+
+   - **EventReporter User Interface** - the newer WinUI-based interface
+     (``adiscon-client-ng``) available alongside the established configuration
+     client.
+
+.. only:: mwagent
+
+   - **MonitorWare Agent User Interface** - the newer WinUI-based interface
+     (``adiscon-client-ng``) available alongside the established configuration
+     client.
+
+.. only:: rsyslog
+
+   - **rsyslog Windows Agent User Interface** - the newer WinUI-based interface
+     (``adiscon-client-ng``) available alongside the established configuration
+     client.
 
 The established configuration client supports license file application and full
 configuration editing. See your product website's **Upgrade** article for the
-customer-facing description of the Product User Interface.
+customer-facing description of the product-specific user interface.
 
 Property window toolbar
 -----------------------

--- a/source/winsyslogspecific/faq.rst
+++ b/source/winsyslogspecific/faq.rst
@@ -54,6 +54,7 @@ Protocols and integration
    ../shared/faq/tls-listener-certificate-files
    faq/originating-ip-address
    faq/setp-vs-syslog
+   faq/eventreporter-properties-via-setp
    faq/non-standard-syslog-format
 
 Licensing and product positioning

--- a/source/winsyslogspecific/faq/eventreporter-properties-via-setp.rst
+++ b/source/winsyslogspecific/faq/eventreporter-properties-via-setp.rst
@@ -1,0 +1,38 @@
+.. _winsyslog-eventreporter-properties-via-setp:
+
+Why can WinSyslog use EventReporter properties?
+===============================================
+
+Question
+--------
+
+Why can WinSyslog rules use EventReporter or Windows Event Log properties when
+WinSyslog does not collect Windows Event Logs locally?
+
+Answer
+------
+
+WinSyslog can use those properties when the event arrives through SETP. SETP
+preserves structured Adiscon event properties, so a WinSyslog ruleset can
+filter, format, and forward those properties after receiving the event.
+
+Details
+-------
+
+This applies to events sent by another Adiscon product, such as EventReporter,
+to a WinSyslog ``SETP Server`` service. WinSyslog receives the structured event
+and processes it through the configured ruleset.
+
+This does not mean that WinSyslog provides EventReporter's local Windows Event
+Log Monitor service. EventReporter collects the Windows Event Log event;
+WinSyslog can process the transported event properties after SETP delivery.
+
+The ``SETP Server`` service is available in WinSyslog Enterprise and Trial.
+Sending events through SETP is a separate sender-side action.
+
+Related information
+-------------------
+
+- :doc:`setp-vs-syslog`
+- :doc:`../tutorial-setp-server`
+- :doc:`../../mwagentspecific/setpserver`


### PR DESCRIPTION
## Summary
- align product capability docs to the intended post-fix state for EventReporter, rsyslog Windows Agent, and WinSyslog
- add rsyslog Windows Agent Resolve Hostname action coverage and include the shared page in its build
- add a WinSyslog FAQ explaining EventReporter/Event Log properties received through SETP
- replace generic Product User Interface wording with product-specific UI names in shared rendered content

## Validation
- `make validate-rst PYTHON=venv/bin/python`
- `make all-html SPHINXOPTS=-W`
- `make spelling`

Validation was run under WSL with `OS` unset and explicit Git worktree variables for spelling because this is a Windows-created worktree.