### PR TITLE
Improve lifecycle and licensing Event ID troubleshooting

### DIFF
--- a/AGENT_ANTIPATTERNS.md
+++ b/AGENT_ANTIPATTERNS.md
@@ -33,6 +33,21 @@ the same issue does not return in later cleanup passes.
 - Do not edit generated troubleshooting pages under
   `source/shared/troubleshooting/event-id/`. Edit the docs-owned procedure
   registry and regenerate.
+- When a shared Event ID procedure serves operations with different intended
+  terminal states, branch its repair and verification by the originating
+  event. Do not assume a startup test after service removal or a denial path
+  for a status-only event.
+- When a native Windows diagnostic may require elevation or a dependent
+  service may be unavailable, state the non-blocking fallback, preserve the
+  query error, and identify any resulting evidence as unverified.
+- For multi-host investigations, direct clock checks on every involved host;
+  do not imply that the affected host's clock proves sender or destination
+  time synchronization.
+- Redact secrets from support evidence, but preserve the host and configuration
+  object identifiers needed to correlate the affected systems and settings.
+- For a permitted-senders refusal, prefer adding or reordering an authorized
+  sender within the active allowance. Do not recommend disabling the sender
+  restriction as a generic repair.
 - Do not publish an Event ID appendix when either the imported Himalaya catalog
   or the procedure catalog is still `draft`. Both review gates are mandatory.
 - Do not expose internal diagnostic keys, source paths, enum names, or C++

--- a/source/_data/event-id-procedures.json
+++ b/source/_data/event-id-procedures.json
@@ -32,32 +32,35 @@
         {
           "instruction": "Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.",
+          "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
           "commands": [
+            "Get-Date -Format o",
+            "w32tm /query /status",
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The output contains the first product failure and later state or recovery events.",
-          "failure": "Increase the bounded time window and verify the Event Log source shown on the Event ID page."
+          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
+        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -90,33 +93,36 @@
       },
       "steps": [
         {
-          "instruction": "Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.",
+          "instruction": "Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "A readable pre-change export exists and its modification time precedes the troubleshooting change.",
+          "failure": "Do not continue with a state-changing repair until a readable pre-change export exists."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.",
           "commands": [
+            "$captureStart=Get-Date; $captureStart.ToString('o')",
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime",
-            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime"
+            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime",
+            "$captureEnd=Get-Date; $captureEnd.ToString('o')"
           ],
-          "expected": "Both files exist, are readable, and cover the recorded reproduction interval.",
-          "failure": "Verify the service account can write the debug directory and restart only if the setting requires it."
+          "expected": "The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.",
+          "failure": "Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.",
+          "failure": "Repeat only after correcting the capture window; do not collect an unbounded debug log."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The capture start and end timestamps, complete Event Log entry, and neighboring product events.",
+        "The pre-change configuration export and bounded debug log from the same interval.",
+        "Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -213,28 +219,31 @@
         {
           "instruction": "Identify the internal Windows service name and intended service account.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The internal service name and intended account are known before any start, stop, or account change.",
+          "failure": "Use the service Properties dialog or the command output below; do not guess the internal name."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.",
           "commands": [
-            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,State,StartMode,StartName,ExitCode",
-            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType"
+            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode",
+            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType",
+            "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
+            "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
+            "Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The service and required dependencies are in the intended state under the intended account.",
-          "failure": "Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure."
+          "expected": "The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.",
+          "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -270,24 +279,24 @@
       },
       "steps": [
         {
-          "instruction": "Export the configuration and open the exact service, rule, filter, or action named in the event.",
+          "instruction": "Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The event detail and Configuration Client identify the same object and a readable pre-change export exists.",
+          "failure": "Do not infer the object from its type alone; collect the complete event and configuration export first."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.",
           "commands": [
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime"
           ],
-          "expected": "A readable pre-change backup exists and all required fields reference valid product objects.",
-          "failure": "Restore the export if the edited configuration cannot load; do not copy objects from another product manual."
+          "expected": "Every required reference resolves to an existing object and every selected feature is available in this product and edition.",
+          "failure": "Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects."
         }
       ],
       "repair_steps": [],
@@ -295,7 +304,7 @@
         "Restore the configuration export created before the change.",
         "Reload the restored configuration and verify the previous behavior."
       ],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -1408,30 +1417,31 @@
         {
           "instruction": "Record product version, displayed license status, edition, and feature named in the event without copying the license payload.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.",
+          "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The signed license targets the running product/version and includes the configured feature.",
-          "failure": "Install the authorized license or disable unsupported configuration; never edit signed data."
+          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
+          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
+        "A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -3362,7 +3372,7 @@
     "legacy.himalaya_servicemanager_cpp_reporterror_reg_trialexp_339": {
       "disposition": "self_service",
       "procedure_ids": [
-        "config.validate-and-reload",
+        "license.verify-license-state",
         "evidence.collect-event-and-neighboring-events",
         "evidence.export-configuration-and-debug-log"
       ],

--- a/source/_data/event-id-procedures.json
+++ b/source/_data/event-id-procedures.json
@@ -3682,6 +3682,58 @@
       ],
       "review_status": "reviewed"
     },
+    "action.shutdown.persistence_failed": {
+      "disposition": "self_service",
+      "procedure_ids": [
+        "file.verify-path-permissions-and-disk-space",
+        "queue.diagnose-backlog-and-disk-queue",
+        "evidence.collect-event-and-neighboring-events",
+        "evidence.export-configuration-and-debug-log"
+      ],
+      "review_status": "reviewed"
+    },
+    "infosource.relp.shutdown_wake_fallback": {
+      "disposition": "self_service",
+      "procedure_ids": [
+        "network.verify-listener-binding-and-firewall",
+        "evidence.collect-event-and-neighboring-events",
+        "evidence.export-configuration-and-debug-log"
+      ],
+      "review_status": "reviewed"
+    },
+    "infosource.snmp.shutdown_wake_fallback": {
+      "disposition": "self_service",
+      "procedure_ids": [
+        "network.verify-listener-binding-and-firewall",
+        "evidence.collect-event-and-neighboring-events",
+        "evidence.export-configuration-and-debug-log"
+      ],
+      "review_status": "reviewed"
+    },
+    "queue.shutdown.enqueue_rejected": {
+      "disposition": "escalation_only",
+      "procedure_ids": [
+        "runtime.collect-escalation-evidence"
+      ],
+      "review_status": "reviewed"
+    },
+    "service.reload.shutdown_incomplete": {
+      "disposition": "escalation_only",
+      "procedure_ids": [
+        "runtime.collect-escalation-evidence"
+      ],
+      "review_status": "reviewed"
+    },
+    "service.shutdown.deadline_expired": {
+      "disposition": "self_service",
+      "procedure_ids": [
+        "service.verify-state-and-account",
+        "queue.diagnose-backlog-and-disk-queue",
+        "evidence.collect-event-and-neighboring-events",
+        "evidence.export-configuration-and-debug-log"
+      ],
+      "review_status": "reviewed"
+    },
     "legacy.himalaya_logrotationsubsystem_cpp_consumed_queue_deletefail_1491": {
       "disposition": "self_service",
       "procedure_ids": [

--- a/source/_data/event-id-procedures.json
+++ b/source/_data/event-id-procedures.json
@@ -36,16 +36,23 @@
           "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
+          "instruction": "For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.",
           "commands": [
             "Get-Date -Format o",
-            "w32tm /query /status",
+            "w32tm /query /status"
+          ],
+          "expected": "Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.",
+          "failure": "If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture."
+        },
+        {
+          "instruction": "On the affected product host, collect only the product events in a bounded window around the event.",
+          "commands": [
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
-          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
+          "expected": "The event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page and expand the window only enough to include the first related event."
         },
         {
           "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
@@ -59,8 +66,8 @@
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
         "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
-        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
-        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
+        "Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -200,7 +207,7 @@
         "rsyslog-client"
       ],
       "review_status": "reviewed",
-      "when_to_use": "Use for service startup, shutdown, permission, and monitoring events.",
+      "when_to_use": "Use for service startup, shutdown, removal, permission, and monitoring events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -235,15 +242,15 @@
           "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
+          "instruction": "After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.",
           "commands": [],
-          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
-          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
+          "expected": "For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
+      "verification": "Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -1398,7 +1405,7 @@
         "rsyslog-client"
       ],
       "review_status": "reviewed",
-      "when_to_use": "Use for trial, license validation, edition, and feature-denied events.",
+      "when_to_use": "Use for trial or registered-status, license-validation, edition, and feature-denied events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -1421,23 +1428,23 @@
           "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
-          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
+          "expected": "For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.",
+          "failure": "For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data."
         },
         {
-          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
+          "instruction": "For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.",
           "commands": [],
-          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "expected": "For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.",
           "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
+      "verification": "For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
@@ -1445,6 +1452,71 @@
       ],
       "optional_tools": [],
       "related_procedures": []
+    },
+    "license.repair-permitted-senders-configuration": {
+      "title": "Repair the permitted-senders configuration",
+      "summary": "Authorize an intended sender without weakening the sender restriction.",
+      "document": "shared/troubleshooting/event-id/license-repair-permitted-senders-configuration",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "review_status": "reviewed",
+      "when_to_use": "Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.",
+      "prerequisites": [
+        "Use an account that can read and update the affected product configuration.",
+        "Replace angle-bracket placeholders with values from the affected system."
+      ],
+      "safety": [
+        "Do not disable permitted-senders protection solely to accept a sender.",
+        "Do not publish sender addresses or a full configuration export."
+      ],
+      "product_paths": {
+        "eventreporter": "Configuration Client > General > permitted-senders settings.",
+        "winsyslog": "Configuration Client > General > permitted-senders settings.",
+        "mwagent": "Configuration Client > General > permitted-senders settings.",
+        "rsyslog-client": "Configuration Client > General > permitted-senders settings."
+      },
+      "steps": [
+        {
+          "instruction": "Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.",
+          "commands": [],
+          "expected": "The intended sender and the active permitted-sender positions are known.",
+          "failure": "Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list."
+        },
+        {
+          "instruction": "Compare the intended sender inventory with the configured count and active entry order.",
+          "commands": [],
+          "expected": "Each required sender is present within the active permitted-sender range.",
+          "failure": "Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection."
+        },
+        {
+          "instruction": "If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.",
+          "commands": [],
+          "expected": "The intended sender is authorized without admitting unapproved senders.",
+          "failure": "Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process."
+        },
+        {
+          "instruction": "Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.",
+          "commands": [],
+          "expected": "The product accepts the test exactly once and Event ID 11043 does not recur.",
+          "failure": "Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary."
+        }
+      ],
+      "repair_steps": [],
+      "rollback_steps": [],
+      "verification": "Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.",
+      "evidence_to_collect": [
+        "The complete Event ID 11043 entry and neighboring product events with timestamps.",
+        "A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.",
+        "The product version and non-secret license allowance when the intended inventory exceeds the configured count."
+      ],
+      "optional_tools": [],
+      "related_procedures": [
+        "license.verify-license-state"
+      ]
     },
     "runtime.collect-escalation-evidence": {
       "title": "Collect evidence for an escalation-only runtime event",
@@ -2042,7 +2114,7 @@
     "legacy.himalaya_clientlichelper_cpp_reporterror_couldntconnect_192": {
       "disposition": "self_service",
       "procedure_ids": [
-        "license.verify-license-state",
+        "license.repair-permitted-senders-configuration",
         "evidence.collect-event-and-neighboring-events",
         "evidence.export-configuration-and-debug-log"
       ],
@@ -3687,6 +3759,15 @@
       "procedure_ids": [
         "file.verify-path-permissions-and-disk-space",
         "queue.diagnose-backlog-and-disk-queue",
+        "evidence.collect-event-and-neighboring-events",
+        "evidence.export-configuration-and-debug-log"
+      ],
+      "review_status": "reviewed"
+    },
+    "action.ringbuffer.not_registered": {
+      "disposition": "self_service",
+      "procedure_ids": [
+        "config.validate-and-reload",
         "evidence.collect-event-and-neighboring-events",
         "evidence.export-configuration-and-debug-log"
       ],

--- a/source/_data/himalaya-event-catalog.json
+++ b/source/_data/himalaya-event-catalog.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "catalog_status": "ready",
-  "source_commit": "3ee9a9b50f5d94487221416de7b536a172b2d816",
+  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
   "products": {
     "eventreporter": {
       "name": "EventReporter",
@@ -26,7 +26,7 @@
       "event_id": 100,
       "kind": "legacy_fixed",
       "severity": "information",
-      "message_pattern": "The service was installed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was installed.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -43,15 +43,14 @@
       "component": "Windows service lifecycle",
       "meaning": "The Windows service registration completed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product installation or explicit service-install operation registered the Windows service."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service installation was intended.",
+        "If the registration was unexpected, identify the installation or administrative action that occurred at the same time.",
+        "Verify the registered service name, executable path, start mode, and service account before starting it."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the intended service registration and that the service can enter the Running state.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -75,7 +74,7 @@
       "event_id": 101,
       "kind": "legacy_fixed",
       "severity": "information",
-      "message_pattern": "The service was removed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was removed.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -92,15 +91,14 @@
       "component": "Windows service lifecycle",
       "meaning": "The Windows service registration was removed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product uninstall or explicit service-remove operation deleted the Windows service registration."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service removal was intended.",
+        "If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.",
+        "Reinstall the service only after confirming that the product files and configuration should remain on this system."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -124,7 +122,7 @@
       "event_id": 102,
       "kind": "legacy_fixed",
       "severity": "error",
-      "message_pattern": "The service could not be removed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service could not be removed.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -139,17 +137,18 @@
       },
       "title": "The service could not be removed",
       "component": "Windows service lifecycle",
-      "meaning": "The Windows service remains registered.",
+      "meaning": "Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The account performing removal lacks permission to delete the service.",
+        "The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.",
+        "The service name or registration state changed during removal."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.",
+        "Confirm the current service registration and whether Windows already marked the service for deletion.",
+        "Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -173,7 +172,7 @@
       "event_id": 103,
       "kind": "legacy_fixed",
       "severity": "error",
-      "message_pattern": "The service control handler could not be installed. Additional detail: {event_detail}",
+      "message_pattern": "The control handler could not be installed.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -188,17 +187,18 @@
       },
       "title": "The service control handler could not be installed",
       "component": "Windows service lifecycle",
-      "meaning": "Windows cannot deliver normal service control requests to the process.",
+      "meaning": "The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The executable was started outside the Service Control Manager instead of as the registered Windows service.",
+        "Windows rejected handler registration because the service process or registration state is invalid.",
+        "A Windows service-control failure occurred during very early startup."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Start the product through Windows Services or Start-Service, not by launching the service executable interactively.",
+        "Check neighboring Service Control Manager events and the registered executable path.",
+        "Repair the product installation if the service registration points to the wrong executable, then perform one controlled start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -222,7 +222,7 @@
       "event_id": 104,
       "kind": "legacy_fixed",
       "severity": "error",
-      "message_pattern": "The service initialization process failed. Additional detail: {event_detail}",
+      "message_pattern": "The initialization process failed.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -237,17 +237,18 @@
       },
       "title": "The service initialization process failed",
       "component": "Windows service lifecycle",
-      "meaning": "The product service did not start.",
+      "meaning": "Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.",
+        "The service account cannot access a required file, registry key, network resource, provider, or certificate.",
+        "A required Windows resource or product component failed during initialization."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.",
+        "Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.",
+        "Correct only the specific earlier failure, then perform one controlled service start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -271,7 +272,7 @@
       "event_id": 105,
       "kind": "legacy_fixed",
       "severity": "information",
-      "message_pattern": "The service was started. Additional detail: {event_detail}",
+      "message_pattern": "The service was started.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -288,15 +289,14 @@
       "component": "Windows service lifecycle",
       "meaning": "The product service entered its running state.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows started the product service and product initialization completed successfully."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the start was intended.",
+        "If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.",
+        "Verify one configured input and destination instead of relying on service state alone."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service remains Running and processes one identifiable event through the intended destination.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -320,7 +320,7 @@
       "event_id": 106,
       "kind": "legacy_fixed",
       "severity": "error",
-      "message_pattern": "The service received an unsupported control request. Additional detail: {event_detail}",
+      "message_pattern": "The service received an unsupported request.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -335,17 +335,17 @@
       },
       "title": "The service received an unsupported control request",
       "component": "Windows service lifecycle",
-      "meaning": "The requested Windows service-control operation was not performed.",
+      "meaning": "Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A management tool or script sent a control code that the product does not support.",
+        "A monitoring or service-management integration used the wrong control operation."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.",
+        "Change the caller to use supported start, stop, or other documented service operations.",
+        "Confirm that the service remains in its intended state after removing the unsupported request."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Run the corrected management operation and confirm the intended service state without Event ID 106.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -369,7 +369,7 @@
       "event_id": 108,
       "kind": "legacy_fixed",
       "severity": "information",
-      "message_pattern": "The service was stopped. Additional detail: {event_detail}",
+      "message_pattern": "The service was stopped.",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -386,15 +386,14 @@
       "component": "Windows service lifecycle",
       "meaning": "The product service completed shutdown.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows, an administrator, an installer, or product shutdown logic requested an orderly stop."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the stop was intended.",
+        "If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.",
+        "Distinguish this orderly stop from a process termination or crash before changing configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -418,7 +417,7 @@
       "event_id": 118,
       "kind": "legacy_fixed",
       "severity": "information",
-      "message_pattern": "The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}",
+      "message_pattern": "The product reports its trial or registered license mode. Additional detail: {license_status_detail}",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -431,19 +430,19 @@
         "mwagent": "AdisconMonitoreWareAgent",
         "rsyslog-client": "RSyslogWindowsAgent"
       },
-      "title": "Trial mode reminder",
+      "title": "Product license status reminder",
       "component": "Licensing",
-      "meaning": "Trial limits and expiration apply to the running product.",
+      "meaning": "The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The service started in trial mode and reports the remaining evaluation period.",
+        "The service started with a valid license and reports the active registered edition."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Read the complete event detail to distinguish trial mode from registered mode.",
+        "No repair is required when the reported mode and edition are expected.",
+        "If the mode is unexpected, compare the running product and version with the displayed license status without copying license data."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service remains Running and that the reported license mode matches the intended product and edition.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -478,15 +477,15 @@
       "component": "Licensing",
       "meaning": "Freeware-mode limits apply to the running WinSyslog service.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The WinSyslog trial expired and the installed version permits continued operation in Free Edition mode.",
+        "No registered WinSyslog license is active, so Free Edition limits apply."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "No repair is required when Free Edition mode is intended.",
+        "Review the active Free Edition limits before relying on additional senders or licensed features.",
+        "If registered operation is intended, install the authorized WinSyslog license and restart the service."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 125 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that WinSyslog reports the intended Free Edition or registered mode and processes one event within that edition's limits.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -518,15 +517,15 @@
       "component": "Licensing",
       "meaning": "The WinSyslog service does not start with the rejected key.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The installed key is invalid, altered, or not issued for this WinSyslog product and version.",
+        "License material was copied incompletely or placed in the wrong product configuration."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running WinSyslog version and displayed license status without copying or editing the key.",
+        "Replace the rejected material with the authorized license issued for this product and version.",
+        "Start WinSyslog once and verify the reported license mode."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 900 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that WinSyslog reaches Running, reports the intended licensed mode, and does not emit Event ID 900 during startup.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -560,15 +559,15 @@
       "component": "Licensing",
       "meaning": "The product service does not start with the blocked key.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The installed key is on the product's blocked-key list and cannot authorize startup.",
+        "License material intended for a different or superseded installation is still configured."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Do not modify or repeatedly re-enter the blocked key.",
+        "Confirm the exact product and version, then obtain and install authorized replacement license material.",
+        "Start the service once and verify the reported license mode."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 901 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service reaches Running, reports the intended licensed mode, and does not emit Event ID 901 during startup.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -850,17 +849,18 @@
       },
       "title": "Configured feature is not licensed",
       "component": "Licensing",
-      "meaning": "The module or option is not loaded at startup.",
+      "meaning": "The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The configuration enables a module that is not included in the installed edition or license.",
+        "A configuration copied from another product or edition contains a feature that is unavailable here.",
+        "The installed signed license does not match the intended product, version, or feature set."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the module kind, module name, and required feature identifier from the complete event detail.",
+        "Confirm the running product, version, edition, and displayed license status without copying the license payload.",
+        "Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -2730,19 +2730,20 @@
         "mwagent": "AdisconMonitoreWareAgent",
         "rsyslog-client": "RSyslogWindowsAgent"
       },
-      "title": "Licensing: connection attempt failed",
-      "component": "Licensing",
-      "meaning": "Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "A sender connection was refused by the permitted-senders limit",
+      "component": "Client connection licensing",
+      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "Permitted Senders is enabled and the configured number of sender entries is already in use.",
+        "The connecting sender is not one of the currently permitted senders.",
+        "The permitted-senders configuration no longer matches the intended sender inventory."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.",
+        "Review the current permitted-senders entries and remove only entries that are confirmed obsolete.",
+        "If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -2779,19 +2780,20 @@
         "mwagent": "AdisconMonitoreWareAgent",
         "rsyslog-client": "RSyslogWindowsAgent"
       },
-      "title": "Licensing: licensed client limit exceeded",
-      "component": "Licensing",
-      "meaning": "Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "A sender connection exceeded the licensed client limit",
+      "component": "Client connection licensing",
+      "meaning": "The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "More distinct senders are connecting than the installed edition or license permits.",
+        "A changed sender address causes an existing device to be counted as an additional client.",
+        "The installed license is not the intended license for this product or system."
       ],
       "troubleshooting_steps": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running product, edition, displayed license status, and client allowance without copying license data.",
+        "Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.",
+        "Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -9645,7 +9647,7 @@
       "event_id": 11186,
       "kind": "structured",
       "severity": "error",
-      "message_pattern": "Servicemanager. Additional detail: {event_detail}",
+      "message_pattern": "ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}",
       "products": [
         "eventreporter",
         "winsyslog",
@@ -9658,19 +9660,19 @@
         "mwagent": "AdisconMonitoreWareAgent",
         "rsyslog-client": "RSyslogWindowsAgent"
       },
-      "title": "Service configuration: trial period expired",
-      "component": "Service configuration",
-      "meaning": "Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "The trial expired and the service was disabled",
+      "component": "Licensing",
+      "meaning": "The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The evaluation period expired and no valid product license is installed.",
+        "The installed license is invalid for the running product or version."
       ],
       "troubleshooting_steps": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Confirm the exact product, version, and displayed license state without copying license data.",
+        "Install the authorized license for this product and version; do not edit signed license content.",
+        "Start the service and verify that its configured inputs load and process one controlled test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.",
+      "success_verification": "Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",

--- a/source/_data/himalaya-event-catalog.json
+++ b/source/_data/himalaya-event-catalog.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "catalog_status": "ready",
-  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
+  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
   "products": {
     "eventreporter": {
       "name": "EventReporter",
@@ -11393,6 +11393,267 @@
         "legacy.himalaya_logrotationsubsystem_cpp_reportwarning_anymsg_600",
         "legacy.himalaya_logrotationsubsystem_cpp_reportwarning_anymsg_610",
         "legacy.himalaya_logrotationsubsystem_cpp_reportwarning_anymsg_624"
+      ]
+    },
+    {
+      "id": "service.shutdown.deadline_expired",
+      "event_id": 11223,
+      "kind": "structured",
+      "severity": "error",
+      "message_pattern": "The protected service shutdown deadline expired; the process will exit without destroying live worker owners. Additional detail: {event_detail}",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "eventreporter": "Adiscon EvntSLog",
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "Protected service shutdown deadline expired",
+      "component": "Service shutdown",
+      "meaning": "Cooperative shutdown did not reach a safe terminal boundary before the configured process-wide deadline.",
+      "likely_causes": [
+        "A source, action callback, queue worker, or log rotation operation exceeded its cancellation or persistence allowance."
+      ],
+      "troubleshooting_steps": [
+        "Review the event detail for the blocking phase and queue counts.",
+        "Correct the blocked component or configure a larger shutdown protection timeout."
+      ],
+      "success_verification": "Stop the service again and confirm that Event ID 11223 does not recur and the process exits within the configured bound.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry and adjacent shutdown events.",
+        "The product version, shutdown configuration, debug log, and queue or ring-buffer configuration."
+      ],
+      "resolution_type": "self_service",
+      "introduced_in": {
+        "eventreporter": "26.08",
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": [
+        "service.reload.shutdown_incomplete",
+        "queue.shutdown.enqueue_rejected"
+      ]
+    },
+    {
+      "id": "service.reload.shutdown_incomplete",
+      "event_id": 11224,
+      "kind": "structured",
+      "severity": "error",
+      "message_pattern": "Configuration reload was stopped because the old runtime did not shut down completely; restart the process. Additional detail: {event_detail}",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "eventreporter": "Adiscon EvntSLog",
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "Configuration reload shutdown incomplete",
+      "component": "Service shutdown",
+      "meaning": "The old runtime could not stop safely, so replacement configuration was not initialized.",
+      "likely_causes": [
+        "A source, action callback, queue worker, or persistence operation did not complete within the configured allowance."
+      ],
+      "troubleshooting_steps": [
+        "Restart the service process.",
+        "Review the event detail for the blocking phase before attempting another reload."
+      ],
+      "success_verification": "Perform one configuration reload and confirm that Event ID 11224 does not recur and the new configuration starts.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry and adjacent reload events.",
+        "The product version, configuration export, and debug log covering the reload."
+      ],
+      "resolution_type": "escalate",
+      "introduced_in": {
+        "eventreporter": "26.08",
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": [
+        "service.shutdown.deadline_expired"
+      ]
+    },
+    {
+      "id": "infosource.relp.shutdown_wake_fallback",
+      "event_id": 11225,
+      "kind": "structured",
+      "severity": "warning",
+      "message_pattern": "The RELP listener loopback wake failed; shutdown is using the bounded external-library fallback. Additional detail: {event_detail}",
+      "products": [
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "RELP listener shutdown wake fallback",
+      "component": "RELP listener",
+      "meaning": "The immediate local wake could not be delivered, so shutdown uses the bounded listener fallback.",
+      "likely_causes": [
+        "Local socket creation or loopback connection failed because of resource pressure or address-family configuration."
+      ],
+      "troubleshooting_steps": [
+        "Check local socket resource usage and the configured RELP listener address and port."
+      ],
+      "success_verification": "Stop an idle RELP listener and confirm that Event ID 11225 does not recur and shutdown completes promptly.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry.",
+        "The RELP listener address family, bind address, port, and debug log."
+      ],
+      "resolution_type": "self_service",
+      "introduced_in": {
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": [
+        "service.shutdown.deadline_expired"
+      ]
+    },
+    {
+      "id": "infosource.snmp.shutdown_wake_fallback",
+      "event_id": 11226,
+      "kind": "structured",
+      "severity": "warning",
+      "message_pattern": "The SNMP listener wake descriptor is unavailable; shutdown is using the bounded select fallback. Additional detail: {event_detail}",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "eventreporter": "Adiscon EvntSLog",
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "SNMP listener shutdown wake fallback",
+      "component": "SNMP trap listener",
+      "meaning": "The local wake descriptor could not be used, so shutdown uses a bounded receive wait.",
+      "likely_causes": [
+        "Local UDP socket setup or send failed, or the descriptor set reached its capacity."
+      ],
+      "troubleshooting_steps": [
+        "Check local socket resource usage and descriptor pressure, then restart the service."
+      ],
+      "success_verification": "Stop an idle SNMP trap listener and confirm that Event ID 11226 does not recur and shutdown completes promptly.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry.",
+        "The SNMP listener configuration and debug log covering shutdown."
+      ],
+      "resolution_type": "self_service",
+      "introduced_in": {
+        "eventreporter": "26.08",
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": [
+        "service.shutdown.deadline_expired"
+      ]
+    },
+    {
+      "id": "queue.shutdown.enqueue_rejected",
+      "event_id": 11227,
+      "kind": "structured",
+      "severity": "warning",
+      "message_pattern": "The main queue rejected an event because shutdown intake is closed. Additional detail: {event_detail}",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "eventreporter": "Adiscon EvntSLog",
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "Event rejected after shutdown intake closed",
+      "component": "Main message queue",
+      "meaning": "A producer submitted an event after all producer owners were expected to have stopped and queue intake had closed.",
+      "likely_causes": [
+        "A producer callback or child worker remained active beyond its documented join boundary."
+      ],
+      "troubleshooting_steps": [
+        "Identify the source active at shutdown and verify that its callbacks and child workers join before owner completion."
+      ],
+      "success_verification": "Repeat the stop or reload and confirm that Event ID 11227 does not recur.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry.",
+        "The source inventory, debug log, and queue drain snapshot."
+      ],
+      "resolution_type": "escalate",
+      "introduced_in": {
+        "eventreporter": "26.08",
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": [
+        "service.shutdown.deadline_expired",
+        "service.reload.shutdown_incomplete"
+      ]
+    },
+    {
+      "id": "action.shutdown.persistence_failed",
+      "event_id": 11228,
+      "kind": "structured",
+      "severity": "error",
+      "message_pattern": "An action disk queue could not be flushed during shutdown; retryable work may be lost. Additional detail: {event_detail}",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "eventreporter": "Adiscon EvntSLog",
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "Action disk queue flush failed during shutdown",
+      "component": "Action persistence",
+      "meaning": "The runtime could not force the affected retry queue data to stable storage at the shutdown boundary.",
+      "likely_causes": [
+        "The disk is full or unavailable, the queue path is inaccessible, or the storage device returned an I/O error."
+      ],
+      "troubleshooting_steps": [
+        "Check free space, storage health, queue-directory permissions, and the Windows system log.",
+        "Preserve the queue files before restarting if recovery is required."
+      ],
+      "success_verification": "Stop the service again and confirm that Event ID 11228 does not recur and the action queue remains recoverable.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry.",
+        "The action queue path, storage free space, permissions, and debug log."
+      ],
+      "resolution_type": "self_service",
+      "introduced_in": {
+        "eventreporter": "26.08",
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": [
+        "service.shutdown.deadline_expired",
+        "service.reload.shutdown_incomplete"
       ]
     }
   ]

--- a/source/_data/himalaya-event-catalog.json
+++ b/source/_data/himalaya-event-catalog.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "catalog_status": "ready",
-  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
+  "source_commit": "6303266429db09363d7bd37e35db26ebff443b90",
   "products": {
     "eventreporter": {
       "name": "EventReporter",
@@ -2732,7 +2732,7 @@
       },
       "title": "A sender connection was refused by the permitted-senders limit",
       "component": "Client connection licensing",
-      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
+      "meaning": "The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.",
       "likely_causes": [
         "Permitted Senders is enabled and the configured number of sender entries is already in use.",
         "The connecting sender is not one of the currently permitted senders.",
@@ -11655,6 +11655,51 @@
         "service.shutdown.deadline_expired",
         "service.reload.shutdown_incomplete"
       ]
+    },
+    {
+      "id": "action.ringbuffer.not_registered",
+      "event_id": 11229,
+      "kind": "structured",
+      "severity": "error",
+      "message_pattern": "A Message Ringbuffer action could not store messages because its buffer is not registered. Additional detail: {event_detail}",
+      "products": [
+        "eventreporter",
+        "winsyslog",
+        "mwagent",
+        "rsyslog-client"
+      ],
+      "event_sources": {
+        "eventreporter": "Adiscon EvntSLog",
+        "winsyslog": "AdisconWinSyslog",
+        "mwagent": "AdisconMonitoreWareAgent",
+        "rsyslog-client": "RSyslogWindowsAgent"
+      },
+      "title": "Message Ringbuffer action is not registered",
+      "component": "Message Ringbuffer action",
+      "meaning": "The action could not retain processed messages because no named buffer is registered for its configured id.",
+      "likely_causes": [
+        "szRingBufferId is empty, invalid, or reserved (diagnostics).",
+        "The service configuration was loaded before the process-wide ringbuffer registry was available.",
+        "The Message Ringbuffer action is disabled or not present in the running configuration."
+      ],
+      "troubleshooting_steps": [
+        "Confirm szRingBufferId is set to a URL-safe id of 1..64 characters and is not diagnostics.",
+        "Save the configuration and restart or reload the service.",
+        "Query GET v1/ringbuffers on the metrics listener and confirm the configured id is listed."
+      ],
+      "success_verification": "Process a message through the action and confirm Event ID 11229 does not recur and the Metrics ringbuffer endpoints return the retained message.",
+      "evidence_to_collect": [
+        "The complete Windows Application Event Log entry.",
+        "The action configuration including szRingBufferId, and a Metrics v1/ringbuffers response."
+      ],
+      "resolution_type": "self_service",
+      "introduced_in": {
+        "eventreporter": "26.08",
+        "winsyslog": "26.08",
+        "mwagent": "26.08",
+        "rsyslog-client": "26.08"
+      },
+      "related_ids": []
     }
   ]
 }

--- a/source/_generated/event-ids/eventreporter/event-ids.json
+++ b/source/_generated/event-ids/eventreporter/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
+  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
   "product": "eventreporter",
   "product_name": "EventReporter",
   "product_version": "26.07",

--- a/source/_generated/event-ids/eventreporter/event-ids.json
+++ b/source/_generated/event-ids/eventreporter/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "3ee9a9b50f5d94487221416de7b536a172b2d816",
+  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
   "product": "eventreporter",
   "product_name": "EventReporter",
   "product_version": "26.07",
@@ -25,32 +25,35 @@
         {
           "instruction": "Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.",
+          "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
           "commands": [
+            "Get-Date -Format o",
+            "w32tm /query /status",
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The output contains the first product failure and later state or recovery events.",
-          "failure": "Increase the bounded time window and verify the Event Log source shown on the Event ID page."
+          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
+        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -220,33 +223,36 @@
       ],
       "steps": [
         {
-          "instruction": "Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.",
+          "instruction": "Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "A readable pre-change export exists and its modification time precedes the troubleshooting change.",
+          "failure": "Do not continue with a state-changing repair until a readable pre-change export exists."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.",
           "commands": [
+            "$captureStart=Get-Date; $captureStart.ToString('o')",
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime",
-            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime"
+            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime",
+            "$captureEnd=Get-Date; $captureEnd.ToString('o')"
           ],
-          "expected": "Both files exist, are readable, and cover the recorded reproduction interval.",
-          "failure": "Verify the service account can write the debug directory and restart only if the setting requires it."
+          "expected": "The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.",
+          "failure": "Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.",
+          "failure": "Repeat only after correcting the capture window; do not collect an unbounded debug log."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The capture start and end timestamps, complete Event Log entry, and neighboring product events.",
+        "The pre-change configuration export and bounded debug log from the same interval.",
+        "Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -465,24 +471,24 @@
       ],
       "steps": [
         {
-          "instruction": "Export the configuration and open the exact service, rule, filter, or action named in the event.",
+          "instruction": "Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The event detail and Configuration Client identify the same object and a readable pre-change export exists.",
+          "failure": "Do not infer the object from its type alone; collect the complete event and configuration export first."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.",
           "commands": [
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime"
           ],
-          "expected": "A readable pre-change backup exists and all required fields reference valid product objects.",
-          "failure": "Restore the export if the edited configuration cannot load; do not copy objects from another product manual."
+          "expected": "Every required reference resolves to an existing object and every selected feature is available in this product and edition.",
+          "failure": "Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects."
         }
       ],
       "repair_steps": [],
@@ -490,7 +496,7 @@
         "Restore the configuration export created before the change.",
         "Reload the restored configuration and verify the previous behavior."
       ],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -966,30 +972,31 @@
         {
           "instruction": "Record product version, displayed license status, edition, and feature named in the event without copying the license payload.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.",
+          "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The signed license targets the running product/version and includes the configured feature.",
-          "failure": "Install the authorized license or disable unsupported configuration; never edit signed data."
+          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
+          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
+        "A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -1061,28 +1068,31 @@
         {
           "instruction": "Identify the internal Windows service name and intended service account.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The internal service name and intended account are known before any start, stop, or account change.",
+          "failure": "Use the service Properties dialog or the command output below; do not guess the internal name."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.",
           "commands": [
-            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,State,StartMode,StartName,ExitCode",
-            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType"
+            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode",
+            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType",
+            "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
+            "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
+            "Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The service and required dependencies are in the intended state under the intended account.",
-          "failure": "Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure."
+          "expected": "The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.",
+          "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -1223,18 +1233,17 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service was installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was installed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was installed.",
       "meaning": "The Windows service registration completed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product installation or explicit service-install operation registered the Windows service."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service installation was intended.",
+        "If the registration was unexpected, identify the installation or administrative action that occurred at the same time.",
+        "Verify the registered service name, executable path, start mode, and service account before starting it."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the intended service registration and that the service can enter the Running state.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1271,18 +1280,17 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service was removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was removed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was removed.",
       "meaning": "The Windows service registration was removed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product uninstall or explicit service-remove operation deleted the Windows service registration."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service removal was intended.",
+        "If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.",
+        "Reinstall the service only after confirming that the product files and configuration should remain on this system."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1319,18 +1327,19 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service could not be removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service could not be removed. Additional detail: {event_detail}",
-      "meaning": "The Windows service remains registered.",
+      "message_pattern": "The {service_name} service could not be removed.",
+      "meaning": "Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The account performing removal lacks permission to delete the service.",
+        "The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.",
+        "The service name or registration state changed during removal."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.",
+        "Confirm the current service registration and whether Windows already marked the service for deletion.",
+        "Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1367,18 +1376,19 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service control handler could not be installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service control handler could not be installed. Additional detail: {event_detail}",
-      "meaning": "Windows cannot deliver normal service control requests to the process.",
+      "message_pattern": "The control handler could not be installed.",
+      "meaning": "The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The executable was started outside the Service Control Manager instead of as the registered Windows service.",
+        "Windows rejected handler registration because the service process or registration state is invalid.",
+        "A Windows service-control failure occurred during very early startup."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Start the product through Windows Services or Start-Service, not by launching the service executable interactively.",
+        "Check neighboring Service Control Manager events and the registered executable path.",
+        "Repair the product installation if the service registration points to the wrong executable, then perform one controlled start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1415,18 +1425,19 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service initialization process failed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service initialization process failed. Additional detail: {event_detail}",
-      "meaning": "The product service did not start.",
+      "message_pattern": "The initialization process failed.",
+      "meaning": "Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.",
+        "The service account cannot access a required file, registry key, network resource, provider, or certificate.",
+        "A required Windows resource or product component failed during initialization."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.",
+        "Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.",
+        "Correct only the specific earlier failure, then perform one controlled service start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1463,18 +1474,17 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service was started",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was started. Additional detail: {event_detail}",
+      "message_pattern": "The service was started.",
       "meaning": "The product service entered its running state.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows started the product service and product initialization completed successfully."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the start was intended.",
+        "If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.",
+        "Verify one configured input and destination instead of relying on service state alone."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service remains Running and processes one identifiable event through the intended destination.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1511,18 +1521,18 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service received an unsupported control request",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service received an unsupported control request. Additional detail: {event_detail}",
-      "meaning": "The requested Windows service-control operation was not performed.",
+      "message_pattern": "The service received an unsupported request.",
+      "meaning": "Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A management tool or script sent a control code that the product does not support.",
+        "A monitoring or service-management integration used the wrong control operation."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.",
+        "Change the caller to use supported start, stop, or other documented service operations.",
+        "Confirm that the service remains in its intended state after removing the unsupported request."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Run the corrected management operation and confirm the intended service state without Event ID 106.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1559,18 +1569,17 @@
       "event_source": "Adiscon EvntSLog",
       "title": "The service was stopped",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was stopped. Additional detail: {event_detail}",
+      "message_pattern": "The service was stopped.",
       "meaning": "The product service completed shutdown.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows, an administrator, an installer, or product shutdown logic requested an orderly stop."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the stop was intended.",
+        "If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.",
+        "Distinguish this orderly stop from a process termination or crash before changing configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1605,20 +1614,20 @@
       "event_id": 118,
       "severity": "information",
       "event_source": "Adiscon EvntSLog",
-      "title": "Trial mode reminder",
+      "title": "Product license status reminder",
       "component": "Licensing",
-      "message_pattern": "The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}",
-      "meaning": "Trial limits and expiration apply to the running product.",
+      "message_pattern": "The product reports its trial or registered license mode. Additional detail: {license_status_detail}",
+      "meaning": "The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The service started in trial mode and reports the remaining evaluation period.",
+        "The service started with a valid license and reports the active registered edition."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Read the complete event detail to distinguish trial mode from registered mode.",
+        "No repair is required when the reported mode and edition are expected.",
+        "If the mode is unexpected, compare the running product and version with the displayed license status without copying license data."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service remains Running and that the reported license mode matches the intended product and edition.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1658,15 +1667,15 @@
       "message_pattern": "The product rejected a blocked license key during startup. Additional detail: {event_detail}",
       "meaning": "The product service does not start with the blocked key.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The installed key is on the product's blocked-key list and cannot authorize startup.",
+        "License material intended for a different or superseded installation is still configured."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Do not modify or repeatedly re-enter the blocked key.",
+        "Confirm the exact product and version, then obtain and install authorized replacement license material.",
+        "Start the service once and verify the reported license mode."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 901 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service reaches Running, reports the intended licensed mode, and does not emit Event ID 901 during startup.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1994,17 +2003,18 @@
       "title": "Configured feature is not licensed",
       "component": "Licensing",
       "message_pattern": "A configured module is not covered by the signed license feature entitlements. Additional detail: {event_detail}",
-      "meaning": "The module or option is not loaded at startup.",
+      "meaning": "The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The configuration enables a module that is not included in the installed edition or license.",
+        "A configuration copied from another product or edition contains a feature that is unavailable here.",
+        "The installed signed license does not match the intended product, version, or feature set."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the module kind, module name, and required feature identifier from the complete event detail.",
+        "Confirm the running product, version, edition, and displayed license status without copying the license payload.",
+        "Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -3955,20 +3965,21 @@
       "event_id": 11043,
       "severity": "error",
       "event_source": "Adiscon EvntSLog",
-      "title": "Licensing: connection attempt failed",
-      "component": "Licensing",
+      "title": "A sender connection was refused by the permitted-senders limit",
+      "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "Permitted Senders is enabled and the configured number of sender entries is already in use.",
+        "The connecting sender is not one of the currently permitted senders.",
+        "The permitted-senders configuration no longer matches the intended sender inventory."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.",
+        "Review the current permitted-senders entries and remove only entries that are confirmed obsolete.",
+        "If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -4003,20 +4014,21 @@
       "event_id": 11044,
       "severity": "error",
       "event_source": "Adiscon EvntSLog",
-      "title": "Licensing: licensed client limit exceeded",
-      "component": "Licensing",
+      "title": "A sender connection exceeded the licensed client limit",
+      "component": "Client connection licensing",
       "message_pattern": "Client license limit exceeded. Additional detail: {event_detail}",
-      "meaning": "Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "More distinct senders are connecting than the installed edition or license permits.",
+        "A changed sender address causes an existing device to be counted as an additional client.",
+        "The installed license is not the intended license for this product or system."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running product, edition, displayed license status, and client allowance without copying license data.",
+        "Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.",
+        "Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -11001,20 +11013,20 @@
       "event_id": 11186,
       "severity": "error",
       "event_source": "Adiscon EvntSLog",
-      "title": "Service configuration: trial period expired",
-      "component": "Service configuration",
-      "message_pattern": "Servicemanager. Additional detail: {event_detail}",
-      "meaning": "Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "The trial expired and the service was disabled",
+      "component": "Licensing",
+      "message_pattern": "ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}",
+      "meaning": "The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The evaluation period expired and no valid product license is installed.",
+        "The installed license is invalid for the running product or version."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Confirm the exact product, version, and displayed license state without copying license data.",
+        "Install the authorized license for this product and version; do not edit signed license content.",
+        "Start the service and verify that its configured inputs load and process one controlled test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.",
+      "success_verification": "Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -11029,9 +11041,9 @@
       ],
       "procedures": [
         {
-          "id": "config.validate-and-reload",
-          "title": "Validate configuration and reload it safely",
-          "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/config-validate-and-reload.html"
+          "id": "license.verify-license-state",
+          "title": "Verify product license and feature entitlement state",
+          "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/eventreporter/event-ids.json
+++ b/source/_generated/event-ids/eventreporter/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
+  "source_commit": "6303266429db09363d7bd37e35db26ebff443b90",
   "product": "eventreporter",
   "product_name": "EventReporter",
   "product_version": "26.07",
@@ -29,16 +29,23 @@
           "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
+          "instruction": "For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.",
           "commands": [
             "Get-Date -Format o",
-            "w32tm /query /status",
+            "w32tm /query /status"
+          ],
+          "expected": "Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.",
+          "failure": "If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture."
+        },
+        {
+          "instruction": "On the affected product host, collect only the product events in a bounded window around the event.",
+          "commands": [
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
-          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
+          "expected": "The event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page and expand the window only enough to include the first related event."
         },
         {
           "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
@@ -52,8 +59,8 @@
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
         "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
-        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
-        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
+        "Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -305,6 +312,59 @@
       "optional_tools": [],
       "related_procedures": [
         "evidence.collect-event-and-neighboring-events"
+      ]
+    },
+    {
+      "id": "license.repair-permitted-senders-configuration",
+      "title": "Repair the permitted-senders configuration",
+      "summary": "Authorize an intended sender without weakening the sender restriction.",
+      "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html",
+      "when_to_use": "Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.",
+      "prerequisites": [
+        "Use an account that can read and update the affected product configuration.",
+        "Replace angle-bracket placeholders with values from the affected system."
+      ],
+      "safety": [
+        "Do not disable permitted-senders protection solely to accept a sender.",
+        "Do not publish sender addresses or a full configuration export."
+      ],
+      "steps": [
+        {
+          "instruction": "Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.",
+          "commands": [],
+          "expected": "The intended sender and the active permitted-sender positions are known.",
+          "failure": "Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list."
+        },
+        {
+          "instruction": "Compare the intended sender inventory with the configured count and active entry order.",
+          "commands": [],
+          "expected": "Each required sender is present within the active permitted-sender range.",
+          "failure": "Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection."
+        },
+        {
+          "instruction": "If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.",
+          "commands": [],
+          "expected": "The intended sender is authorized without admitting unapproved senders.",
+          "failure": "Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process."
+        },
+        {
+          "instruction": "Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.",
+          "commands": [],
+          "expected": "The product accepts the test exactly once and Event ID 11043 does not recur.",
+          "failure": "Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary."
+        }
+      ],
+      "repair_steps": [],
+      "rollback_steps": [],
+      "verification": "Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.",
+      "evidence_to_collect": [
+        "The complete Event ID 11043 entry and neighboring product events with timestamps.",
+        "A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.",
+        "The product version and non-secret license allowance when the intended inventory exceeds the configured count."
+      ],
+      "optional_tools": [],
+      "related_procedures": [
+        "license.verify-license-state"
       ]
     },
     {
@@ -959,7 +1019,7 @@
       "title": "Verify product license and feature entitlement state",
       "summary": "Confirm product, version, validity, edition, and required feature without exposing license data.",
       "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.html",
-      "when_to_use": "Use for trial, license validation, edition, and feature-denied events.",
+      "when_to_use": "Use for trial or registered-status, license-validation, edition, and feature-denied events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -976,23 +1036,23 @@
           "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
-          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
+          "expected": "For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.",
+          "failure": "For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data."
         },
         {
-          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
+          "instruction": "For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.",
           "commands": [],
-          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "expected": "For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.",
           "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
+      "verification": "For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
@@ -1055,7 +1115,7 @@
       "title": "Verify service state, dependencies, and service account",
       "summary": "Confirm service state, start mode, dependencies, account, and SCM errors.",
       "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/service-verify-state-and-account.html",
-      "when_to_use": "Use for service startup, shutdown, permission, and monitoring events.",
+      "when_to_use": "Use for service startup, shutdown, removal, permission, and monitoring events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -1084,15 +1144,15 @@
           "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
+          "instruction": "After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.",
           "commands": [],
-          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
-          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
+          "expected": "For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
+      "verification": "Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -3968,7 +4028,7 @@
       "title": "A sender connection was refused by the permitted-senders limit",
       "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
+      "meaning": "The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.",
       "likely_causes": [
         "Permitted Senders is enabled and the configured number of sender entries is already in use.",
         "The connecting sender is not one of the currently permitted senders.",
@@ -3994,9 +4054,9 @@
       ],
       "procedures": [
         {
-          "id": "license.verify-license-state",
-          "title": "Verify product license and feature entitlement state",
-          "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.html"
+          "id": "license.repair-permitted-senders-configuration",
+          "title": "Repair the permitted-senders configuration",
+          "url": "https://www.eventreporter.com/files/manual/eventreporterspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/mwagent/event-ids.json
+++ b/source/_generated/event-ids/mwagent/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
+  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
   "product": "mwagent",
   "product_name": "MonitorWare Agent",
   "product_version": "26.07",

--- a/source/_generated/event-ids/mwagent/event-ids.json
+++ b/source/_generated/event-ids/mwagent/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "3ee9a9b50f5d94487221416de7b536a172b2d816",
+  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
   "product": "mwagent",
   "product_name": "MonitorWare Agent",
   "product_version": "26.07",
@@ -25,32 +25,35 @@
         {
           "instruction": "Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.",
+          "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
           "commands": [
+            "Get-Date -Format o",
+            "w32tm /query /status",
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The output contains the first product failure and later state or recovery events.",
-          "failure": "Increase the bounded time window and verify the Event Log source shown on the Event ID page."
+          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
+        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -220,33 +223,36 @@
       ],
       "steps": [
         {
-          "instruction": "Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.",
+          "instruction": "Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "A readable pre-change export exists and its modification time precedes the troubleshooting change.",
+          "failure": "Do not continue with a state-changing repair until a readable pre-change export exists."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.",
           "commands": [
+            "$captureStart=Get-Date; $captureStart.ToString('o')",
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime",
-            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime"
+            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime",
+            "$captureEnd=Get-Date; $captureEnd.ToString('o')"
           ],
-          "expected": "Both files exist, are readable, and cover the recorded reproduction interval.",
-          "failure": "Verify the service account can write the debug directory and restart only if the setting requires it."
+          "expected": "The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.",
+          "failure": "Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.",
+          "failure": "Repeat only after correcting the capture window; do not collect an unbounded debug log."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The capture start and end timestamps, complete Event Log entry, and neighboring product events.",
+        "The pre-change configuration export and bounded debug log from the same interval.",
+        "Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -465,24 +471,24 @@
       ],
       "steps": [
         {
-          "instruction": "Export the configuration and open the exact service, rule, filter, or action named in the event.",
+          "instruction": "Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The event detail and Configuration Client identify the same object and a readable pre-change export exists.",
+          "failure": "Do not infer the object from its type alone; collect the complete event and configuration export first."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.",
           "commands": [
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime"
           ],
-          "expected": "A readable pre-change backup exists and all required fields reference valid product objects.",
-          "failure": "Restore the export if the edited configuration cannot load; do not copy objects from another product manual."
+          "expected": "Every required reference resolves to an existing object and every selected feature is available in this product and edition.",
+          "failure": "Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects."
         }
       ],
       "repair_steps": [],
@@ -490,7 +496,7 @@
         "Restore the configuration export created before the change.",
         "Reload the restored configuration and verify the previous behavior."
       ],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -966,30 +972,31 @@
         {
           "instruction": "Record product version, displayed license status, edition, and feature named in the event without copying the license payload.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.",
+          "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The signed license targets the running product/version and includes the configured feature.",
-          "failure": "Install the authorized license or disable unsupported configuration; never edit signed data."
+          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
+          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
+        "A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -1061,28 +1068,31 @@
         {
           "instruction": "Identify the internal Windows service name and intended service account.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The internal service name and intended account are known before any start, stop, or account change.",
+          "failure": "Use the service Properties dialog or the command output below; do not guess the internal name."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.",
           "commands": [
-            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,State,StartMode,StartName,ExitCode",
-            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType"
+            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode",
+            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType",
+            "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
+            "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
+            "Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The service and required dependencies are in the intended state under the intended account.",
-          "failure": "Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure."
+          "expected": "The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.",
+          "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -1223,18 +1233,17 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service was installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was installed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was installed.",
       "meaning": "The Windows service registration completed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product installation or explicit service-install operation registered the Windows service."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service installation was intended.",
+        "If the registration was unexpected, identify the installation or administrative action that occurred at the same time.",
+        "Verify the registered service name, executable path, start mode, and service account before starting it."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the intended service registration and that the service can enter the Running state.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1271,18 +1280,17 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service was removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was removed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was removed.",
       "meaning": "The Windows service registration was removed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product uninstall or explicit service-remove operation deleted the Windows service registration."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service removal was intended.",
+        "If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.",
+        "Reinstall the service only after confirming that the product files and configuration should remain on this system."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1319,18 +1327,19 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service could not be removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service could not be removed. Additional detail: {event_detail}",
-      "meaning": "The Windows service remains registered.",
+      "message_pattern": "The {service_name} service could not be removed.",
+      "meaning": "Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The account performing removal lacks permission to delete the service.",
+        "The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.",
+        "The service name or registration state changed during removal."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.",
+        "Confirm the current service registration and whether Windows already marked the service for deletion.",
+        "Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1367,18 +1376,19 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service control handler could not be installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service control handler could not be installed. Additional detail: {event_detail}",
-      "meaning": "Windows cannot deliver normal service control requests to the process.",
+      "message_pattern": "The control handler could not be installed.",
+      "meaning": "The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The executable was started outside the Service Control Manager instead of as the registered Windows service.",
+        "Windows rejected handler registration because the service process or registration state is invalid.",
+        "A Windows service-control failure occurred during very early startup."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Start the product through Windows Services or Start-Service, not by launching the service executable interactively.",
+        "Check neighboring Service Control Manager events and the registered executable path.",
+        "Repair the product installation if the service registration points to the wrong executable, then perform one controlled start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1415,18 +1425,19 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service initialization process failed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service initialization process failed. Additional detail: {event_detail}",
-      "meaning": "The product service did not start.",
+      "message_pattern": "The initialization process failed.",
+      "meaning": "Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.",
+        "The service account cannot access a required file, registry key, network resource, provider, or certificate.",
+        "A required Windows resource or product component failed during initialization."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.",
+        "Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.",
+        "Correct only the specific earlier failure, then perform one controlled service start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1463,18 +1474,17 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service was started",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was started. Additional detail: {event_detail}",
+      "message_pattern": "The service was started.",
       "meaning": "The product service entered its running state.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows started the product service and product initialization completed successfully."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the start was intended.",
+        "If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.",
+        "Verify one configured input and destination instead of relying on service state alone."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service remains Running and processes one identifiable event through the intended destination.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1511,18 +1521,18 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service received an unsupported control request",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service received an unsupported control request. Additional detail: {event_detail}",
-      "meaning": "The requested Windows service-control operation was not performed.",
+      "message_pattern": "The service received an unsupported request.",
+      "meaning": "Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A management tool or script sent a control code that the product does not support.",
+        "A monitoring or service-management integration used the wrong control operation."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.",
+        "Change the caller to use supported start, stop, or other documented service operations.",
+        "Confirm that the service remains in its intended state after removing the unsupported request."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Run the corrected management operation and confirm the intended service state without Event ID 106.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1559,18 +1569,17 @@
       "event_source": "AdisconMonitoreWareAgent",
       "title": "The service was stopped",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was stopped. Additional detail: {event_detail}",
+      "message_pattern": "The service was stopped.",
       "meaning": "The product service completed shutdown.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows, an administrator, an installer, or product shutdown logic requested an orderly stop."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the stop was intended.",
+        "If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.",
+        "Distinguish this orderly stop from a process termination or crash before changing configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1605,20 +1614,20 @@
       "event_id": 118,
       "severity": "information",
       "event_source": "AdisconMonitoreWareAgent",
-      "title": "Trial mode reminder",
+      "title": "Product license status reminder",
       "component": "Licensing",
-      "message_pattern": "The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}",
-      "meaning": "Trial limits and expiration apply to the running product.",
+      "message_pattern": "The product reports its trial or registered license mode. Additional detail: {license_status_detail}",
+      "meaning": "The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The service started in trial mode and reports the remaining evaluation period.",
+        "The service started with a valid license and reports the active registered edition."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Read the complete event detail to distinguish trial mode from registered mode.",
+        "No repair is required when the reported mode and edition are expected.",
+        "If the mode is unexpected, compare the running product and version with the displayed license status without copying license data."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service remains Running and that the reported license mode matches the intended product and edition.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1946,17 +1955,18 @@
       "title": "Configured feature is not licensed",
       "component": "Licensing",
       "message_pattern": "A configured module is not covered by the signed license feature entitlements. Additional detail: {event_detail}",
-      "meaning": "The module or option is not loaded at startup.",
+      "meaning": "The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The configuration enables a module that is not included in the installed edition or license.",
+        "A configuration copied from another product or edition contains a feature that is unavailable here.",
+        "The installed signed license does not match the intended product, version, or feature set."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the module kind, module name, and required feature identifier from the complete event detail.",
+        "Confirm the running product, version, edition, and displayed license status without copying the license payload.",
+        "Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -3907,20 +3917,21 @@
       "event_id": 11043,
       "severity": "error",
       "event_source": "AdisconMonitoreWareAgent",
-      "title": "Licensing: connection attempt failed",
-      "component": "Licensing",
+      "title": "A sender connection was refused by the permitted-senders limit",
+      "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "Permitted Senders is enabled and the configured number of sender entries is already in use.",
+        "The connecting sender is not one of the currently permitted senders.",
+        "The permitted-senders configuration no longer matches the intended sender inventory."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.",
+        "Review the current permitted-senders entries and remove only entries that are confirmed obsolete.",
+        "If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -3955,20 +3966,21 @@
       "event_id": 11044,
       "severity": "error",
       "event_source": "AdisconMonitoreWareAgent",
-      "title": "Licensing: licensed client limit exceeded",
-      "component": "Licensing",
+      "title": "A sender connection exceeded the licensed client limit",
+      "component": "Client connection licensing",
       "message_pattern": "Client license limit exceeded. Additional detail: {event_detail}",
-      "meaning": "Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "More distinct senders are connecting than the installed edition or license permits.",
+        "A changed sender address causes an existing device to be counted as an additional client.",
+        "The installed license is not the intended license for this product or system."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running product, edition, displayed license status, and client allowance without copying license data.",
+        "Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.",
+        "Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -10951,20 +10963,20 @@
       "event_id": 11186,
       "severity": "error",
       "event_source": "AdisconMonitoreWareAgent",
-      "title": "Service configuration: trial period expired",
-      "component": "Service configuration",
-      "message_pattern": "Servicemanager. Additional detail: {event_detail}",
-      "meaning": "Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "The trial expired and the service was disabled",
+      "component": "Licensing",
+      "message_pattern": "ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}",
+      "meaning": "The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The evaluation period expired and no valid product license is installed.",
+        "The installed license is invalid for the running product or version."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Confirm the exact product, version, and displayed license state without copying license data.",
+        "Install the authorized license for this product and version; do not edit signed license content.",
+        "Start the service and verify that its configured inputs load and process one controlled test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.",
+      "success_verification": "Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -10979,9 +10991,9 @@
       ],
       "procedures": [
         {
-          "id": "config.validate-and-reload",
-          "title": "Validate configuration and reload it safely",
-          "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/config-validate-and-reload.html"
+          "id": "license.verify-license-state",
+          "title": "Verify product license and feature entitlement state",
+          "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/license-verify-license-state.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/mwagent/event-ids.json
+++ b/source/_generated/event-ids/mwagent/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
+  "source_commit": "6303266429db09363d7bd37e35db26ebff443b90",
   "product": "mwagent",
   "product_name": "MonitorWare Agent",
   "product_version": "26.07",
@@ -29,16 +29,23 @@
           "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
+          "instruction": "For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.",
           "commands": [
             "Get-Date -Format o",
-            "w32tm /query /status",
+            "w32tm /query /status"
+          ],
+          "expected": "Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.",
+          "failure": "If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture."
+        },
+        {
+          "instruction": "On the affected product host, collect only the product events in a bounded window around the event.",
+          "commands": [
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
-          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
+          "expected": "The event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page and expand the window only enough to include the first related event."
         },
         {
           "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
@@ -52,8 +59,8 @@
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
         "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
-        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
-        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
+        "Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -305,6 +312,59 @@
       "optional_tools": [],
       "related_procedures": [
         "evidence.collect-event-and-neighboring-events"
+      ]
+    },
+    {
+      "id": "license.repair-permitted-senders-configuration",
+      "title": "Repair the permitted-senders configuration",
+      "summary": "Authorize an intended sender without weakening the sender restriction.",
+      "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html",
+      "when_to_use": "Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.",
+      "prerequisites": [
+        "Use an account that can read and update the affected product configuration.",
+        "Replace angle-bracket placeholders with values from the affected system."
+      ],
+      "safety": [
+        "Do not disable permitted-senders protection solely to accept a sender.",
+        "Do not publish sender addresses or a full configuration export."
+      ],
+      "steps": [
+        {
+          "instruction": "Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.",
+          "commands": [],
+          "expected": "The intended sender and the active permitted-sender positions are known.",
+          "failure": "Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list."
+        },
+        {
+          "instruction": "Compare the intended sender inventory with the configured count and active entry order.",
+          "commands": [],
+          "expected": "Each required sender is present within the active permitted-sender range.",
+          "failure": "Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection."
+        },
+        {
+          "instruction": "If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.",
+          "commands": [],
+          "expected": "The intended sender is authorized without admitting unapproved senders.",
+          "failure": "Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process."
+        },
+        {
+          "instruction": "Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.",
+          "commands": [],
+          "expected": "The product accepts the test exactly once and Event ID 11043 does not recur.",
+          "failure": "Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary."
+        }
+      ],
+      "repair_steps": [],
+      "rollback_steps": [],
+      "verification": "Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.",
+      "evidence_to_collect": [
+        "The complete Event ID 11043 entry and neighboring product events with timestamps.",
+        "A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.",
+        "The product version and non-secret license allowance when the intended inventory exceeds the configured count."
+      ],
+      "optional_tools": [],
+      "related_procedures": [
+        "license.verify-license-state"
       ]
     },
     {
@@ -959,7 +1019,7 @@
       "title": "Verify product license and feature entitlement state",
       "summary": "Confirm product, version, validity, edition, and required feature without exposing license data.",
       "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/license-verify-license-state.html",
-      "when_to_use": "Use for trial, license validation, edition, and feature-denied events.",
+      "when_to_use": "Use for trial or registered-status, license-validation, edition, and feature-denied events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -976,23 +1036,23 @@
           "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
-          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
+          "expected": "For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.",
+          "failure": "For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data."
         },
         {
-          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
+          "instruction": "For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.",
           "commands": [],
-          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "expected": "For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.",
           "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
+      "verification": "For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
@@ -1055,7 +1115,7 @@
       "title": "Verify service state, dependencies, and service account",
       "summary": "Confirm service state, start mode, dependencies, account, and SCM errors.",
       "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/service-verify-state-and-account.html",
-      "when_to_use": "Use for service startup, shutdown, permission, and monitoring events.",
+      "when_to_use": "Use for service startup, shutdown, removal, permission, and monitoring events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -1084,15 +1144,15 @@
           "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
+          "instruction": "After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.",
           "commands": [],
-          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
-          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
+          "expected": "For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
+      "verification": "Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -3920,7 +3980,7 @@
       "title": "A sender connection was refused by the permitted-senders limit",
       "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
+      "meaning": "The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.",
       "likely_causes": [
         "Permitted Senders is enabled and the configured number of sender entries is already in use.",
         "The connecting sender is not one of the currently permitted senders.",
@@ -3946,9 +4006,9 @@
       ],
       "procedures": [
         {
-          "id": "license.verify-license-state",
-          "title": "Verify product license and feature entitlement state",
-          "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/license-verify-license-state.html"
+          "id": "license.repair-permitted-senders-configuration",
+          "title": "Repair the permitted-senders configuration",
+          "url": "https://www.mwagent.com/files/manual/current/mwagentspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/rsyslog-client/event-ids.json
+++ b/source/_generated/event-ids/rsyslog-client/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "3ee9a9b50f5d94487221416de7b536a172b2d816",
+  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
   "product": "rsyslog-client",
   "product_name": "rsyslog Windows Agent",
   "product_version": "26.07",
@@ -25,32 +25,35 @@
         {
           "instruction": "Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.",
+          "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
           "commands": [
+            "Get-Date -Format o",
+            "w32tm /query /status",
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The output contains the first product failure and later state or recovery events.",
-          "failure": "Increase the bounded time window and verify the Event Log source shown on the Event ID page."
+          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
+        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -220,33 +223,36 @@
       ],
       "steps": [
         {
-          "instruction": "Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.",
+          "instruction": "Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "A readable pre-change export exists and its modification time precedes the troubleshooting change.",
+          "failure": "Do not continue with a state-changing repair until a readable pre-change export exists."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.",
           "commands": [
+            "$captureStart=Get-Date; $captureStart.ToString('o')",
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime",
-            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime"
+            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime",
+            "$captureEnd=Get-Date; $captureEnd.ToString('o')"
           ],
-          "expected": "Both files exist, are readable, and cover the recorded reproduction interval.",
-          "failure": "Verify the service account can write the debug directory and restart only if the setting requires it."
+          "expected": "The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.",
+          "failure": "Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.",
+          "failure": "Repeat only after correcting the capture window; do not collect an unbounded debug log."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The capture start and end timestamps, complete Event Log entry, and neighboring product events.",
+        "The pre-change configuration export and bounded debug log from the same interval.",
+        "Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -465,24 +471,24 @@
       ],
       "steps": [
         {
-          "instruction": "Export the configuration and open the exact service, rule, filter, or action named in the event.",
+          "instruction": "Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The event detail and Configuration Client identify the same object and a readable pre-change export exists.",
+          "failure": "Do not infer the object from its type alone; collect the complete event and configuration export first."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.",
           "commands": [
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime"
           ],
-          "expected": "A readable pre-change backup exists and all required fields reference valid product objects.",
-          "failure": "Restore the export if the edited configuration cannot load; do not copy objects from another product manual."
+          "expected": "Every required reference resolves to an existing object and every selected feature is available in this product and edition.",
+          "failure": "Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects."
         }
       ],
       "repair_steps": [],
@@ -490,7 +496,7 @@
         "Restore the configuration export created before the change.",
         "Reload the restored configuration and verify the previous behavior."
       ],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -966,30 +972,31 @@
         {
           "instruction": "Record product version, displayed license status, edition, and feature named in the event without copying the license payload.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.",
+          "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The signed license targets the running product/version and includes the configured feature.",
-          "failure": "Install the authorized license or disable unsupported configuration; never edit signed data."
+          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
+          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
+        "A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -1061,28 +1068,31 @@
         {
           "instruction": "Identify the internal Windows service name and intended service account.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The internal service name and intended account are known before any start, stop, or account change.",
+          "failure": "Use the service Properties dialog or the command output below; do not guess the internal name."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.",
           "commands": [
-            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,State,StartMode,StartName,ExitCode",
-            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType"
+            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode",
+            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType",
+            "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
+            "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
+            "Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The service and required dependencies are in the intended state under the intended account.",
-          "failure": "Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure."
+          "expected": "The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.",
+          "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -1223,18 +1233,17 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service was installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was installed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was installed.",
       "meaning": "The Windows service registration completed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product installation or explicit service-install operation registered the Windows service."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service installation was intended.",
+        "If the registration was unexpected, identify the installation or administrative action that occurred at the same time.",
+        "Verify the registered service name, executable path, start mode, and service account before starting it."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the intended service registration and that the service can enter the Running state.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1271,18 +1280,17 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service was removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was removed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was removed.",
       "meaning": "The Windows service registration was removed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product uninstall or explicit service-remove operation deleted the Windows service registration."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service removal was intended.",
+        "If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.",
+        "Reinstall the service only after confirming that the product files and configuration should remain on this system."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1319,18 +1327,19 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service could not be removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service could not be removed. Additional detail: {event_detail}",
-      "meaning": "The Windows service remains registered.",
+      "message_pattern": "The {service_name} service could not be removed.",
+      "meaning": "Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The account performing removal lacks permission to delete the service.",
+        "The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.",
+        "The service name or registration state changed during removal."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.",
+        "Confirm the current service registration and whether Windows already marked the service for deletion.",
+        "Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1367,18 +1376,19 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service control handler could not be installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service control handler could not be installed. Additional detail: {event_detail}",
-      "meaning": "Windows cannot deliver normal service control requests to the process.",
+      "message_pattern": "The control handler could not be installed.",
+      "meaning": "The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The executable was started outside the Service Control Manager instead of as the registered Windows service.",
+        "Windows rejected handler registration because the service process or registration state is invalid.",
+        "A Windows service-control failure occurred during very early startup."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Start the product through Windows Services or Start-Service, not by launching the service executable interactively.",
+        "Check neighboring Service Control Manager events and the registered executable path.",
+        "Repair the product installation if the service registration points to the wrong executable, then perform one controlled start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1415,18 +1425,19 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service initialization process failed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service initialization process failed. Additional detail: {event_detail}",
-      "meaning": "The product service did not start.",
+      "message_pattern": "The initialization process failed.",
+      "meaning": "Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.",
+        "The service account cannot access a required file, registry key, network resource, provider, or certificate.",
+        "A required Windows resource or product component failed during initialization."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.",
+        "Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.",
+        "Correct only the specific earlier failure, then perform one controlled service start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1463,18 +1474,17 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service was started",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was started. Additional detail: {event_detail}",
+      "message_pattern": "The service was started.",
       "meaning": "The product service entered its running state.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows started the product service and product initialization completed successfully."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the start was intended.",
+        "If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.",
+        "Verify one configured input and destination instead of relying on service state alone."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service remains Running and processes one identifiable event through the intended destination.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1511,18 +1521,18 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service received an unsupported control request",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service received an unsupported control request. Additional detail: {event_detail}",
-      "meaning": "The requested Windows service-control operation was not performed.",
+      "message_pattern": "The service received an unsupported request.",
+      "meaning": "Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A management tool or script sent a control code that the product does not support.",
+        "A monitoring or service-management integration used the wrong control operation."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.",
+        "Change the caller to use supported start, stop, or other documented service operations.",
+        "Confirm that the service remains in its intended state after removing the unsupported request."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Run the corrected management operation and confirm the intended service state without Event ID 106.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1559,18 +1569,17 @@
       "event_source": "RSyslogWindowsAgent",
       "title": "The service was stopped",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was stopped. Additional detail: {event_detail}",
+      "message_pattern": "The service was stopped.",
       "meaning": "The product service completed shutdown.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows, an administrator, an installer, or product shutdown logic requested an orderly stop."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the stop was intended.",
+        "If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.",
+        "Distinguish this orderly stop from a process termination or crash before changing configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1605,20 +1614,20 @@
       "event_id": 118,
       "severity": "information",
       "event_source": "RSyslogWindowsAgent",
-      "title": "Trial mode reminder",
+      "title": "Product license status reminder",
       "component": "Licensing",
-      "message_pattern": "The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}",
-      "meaning": "Trial limits and expiration apply to the running product.",
+      "message_pattern": "The product reports its trial or registered license mode. Additional detail: {license_status_detail}",
+      "meaning": "The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The service started in trial mode and reports the remaining evaluation period.",
+        "The service started with a valid license and reports the active registered edition."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Read the complete event detail to distinguish trial mode from registered mode.",
+        "No repair is required when the reported mode and edition are expected.",
+        "If the mode is unexpected, compare the running product and version with the displayed license status without copying license data."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service remains Running and that the reported license mode matches the intended product and edition.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1946,17 +1955,18 @@
       "title": "Configured feature is not licensed",
       "component": "Licensing",
       "message_pattern": "A configured module is not covered by the signed license feature entitlements. Additional detail: {event_detail}",
-      "meaning": "The module or option is not loaded at startup.",
+      "meaning": "The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The configuration enables a module that is not included in the installed edition or license.",
+        "A configuration copied from another product or edition contains a feature that is unavailable here.",
+        "The installed signed license does not match the intended product, version, or feature set."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the module kind, module name, and required feature identifier from the complete event detail.",
+        "Confirm the running product, version, edition, and displayed license status without copying the license payload.",
+        "Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -3907,20 +3917,21 @@
       "event_id": 11043,
       "severity": "error",
       "event_source": "RSyslogWindowsAgent",
-      "title": "Licensing: connection attempt failed",
-      "component": "Licensing",
+      "title": "A sender connection was refused by the permitted-senders limit",
+      "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "Permitted Senders is enabled and the configured number of sender entries is already in use.",
+        "The connecting sender is not one of the currently permitted senders.",
+        "The permitted-senders configuration no longer matches the intended sender inventory."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.",
+        "Review the current permitted-senders entries and remove only entries that are confirmed obsolete.",
+        "If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -3955,20 +3966,21 @@
       "event_id": 11044,
       "severity": "error",
       "event_source": "RSyslogWindowsAgent",
-      "title": "Licensing: licensed client limit exceeded",
-      "component": "Licensing",
+      "title": "A sender connection exceeded the licensed client limit",
+      "component": "Client connection licensing",
       "message_pattern": "Client license limit exceeded. Additional detail: {event_detail}",
-      "meaning": "Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "More distinct senders are connecting than the installed edition or license permits.",
+        "A changed sender address causes an existing device to be counted as an additional client.",
+        "The installed license is not the intended license for this product or system."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running product, edition, displayed license status, and client allowance without copying license data.",
+        "Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.",
+        "Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -10951,20 +10963,20 @@
       "event_id": 11186,
       "severity": "error",
       "event_source": "RSyslogWindowsAgent",
-      "title": "Service configuration: trial period expired",
-      "component": "Service configuration",
-      "message_pattern": "Servicemanager. Additional detail: {event_detail}",
-      "meaning": "Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "The trial expired and the service was disabled",
+      "component": "Licensing",
+      "message_pattern": "ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}",
+      "meaning": "The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The evaluation period expired and no valid product license is installed.",
+        "The installed license is invalid for the running product or version."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Confirm the exact product, version, and displayed license state without copying license data.",
+        "Install the authorized license for this product and version; do not edit signed license content.",
+        "Start the service and verify that its configured inputs load and process one controlled test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.",
+      "success_verification": "Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -10979,9 +10991,9 @@
       ],
       "procedures": [
         {
-          "id": "config.validate-and-reload",
-          "title": "Validate configuration and reload it safely",
-          "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/config-validate-and-reload.html"
+          "id": "license.verify-license-state",
+          "title": "Verify product license and feature entitlement state",
+          "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/rsyslog-client/event-ids.json
+++ b/source/_generated/event-ids/rsyslog-client/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
+  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
   "product": "rsyslog-client",
   "product_name": "rsyslog Windows Agent",
   "product_version": "26.07",

--- a/source/_generated/event-ids/rsyslog-client/event-ids.json
+++ b/source/_generated/event-ids/rsyslog-client/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
+  "source_commit": "6303266429db09363d7bd37e35db26ebff443b90",
   "product": "rsyslog-client",
   "product_name": "rsyslog Windows Agent",
   "product_version": "26.07",
@@ -29,16 +29,23 @@
           "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
+          "instruction": "For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.",
           "commands": [
             "Get-Date -Format o",
-            "w32tm /query /status",
+            "w32tm /query /status"
+          ],
+          "expected": "Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.",
+          "failure": "If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture."
+        },
+        {
+          "instruction": "On the affected product host, collect only the product events in a bounded window around the event.",
+          "commands": [
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
-          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
+          "expected": "The event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page and expand the window only enough to include the first related event."
         },
         {
           "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
@@ -52,8 +59,8 @@
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
         "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
-        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
-        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
+        "Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -305,6 +312,59 @@
       "optional_tools": [],
       "related_procedures": [
         "evidence.collect-event-and-neighboring-events"
+      ]
+    },
+    {
+      "id": "license.repair-permitted-senders-configuration",
+      "title": "Repair the permitted-senders configuration",
+      "summary": "Authorize an intended sender without weakening the sender restriction.",
+      "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html",
+      "when_to_use": "Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.",
+      "prerequisites": [
+        "Use an account that can read and update the affected product configuration.",
+        "Replace angle-bracket placeholders with values from the affected system."
+      ],
+      "safety": [
+        "Do not disable permitted-senders protection solely to accept a sender.",
+        "Do not publish sender addresses or a full configuration export."
+      ],
+      "steps": [
+        {
+          "instruction": "Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.",
+          "commands": [],
+          "expected": "The intended sender and the active permitted-sender positions are known.",
+          "failure": "Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list."
+        },
+        {
+          "instruction": "Compare the intended sender inventory with the configured count and active entry order.",
+          "commands": [],
+          "expected": "Each required sender is present within the active permitted-sender range.",
+          "failure": "Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection."
+        },
+        {
+          "instruction": "If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.",
+          "commands": [],
+          "expected": "The intended sender is authorized without admitting unapproved senders.",
+          "failure": "Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process."
+        },
+        {
+          "instruction": "Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.",
+          "commands": [],
+          "expected": "The product accepts the test exactly once and Event ID 11043 does not recur.",
+          "failure": "Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary."
+        }
+      ],
+      "repair_steps": [],
+      "rollback_steps": [],
+      "verification": "Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.",
+      "evidence_to_collect": [
+        "The complete Event ID 11043 entry and neighboring product events with timestamps.",
+        "A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.",
+        "The product version and non-secret license allowance when the intended inventory exceeds the configured count."
+      ],
+      "optional_tools": [],
+      "related_procedures": [
+        "license.verify-license-state"
       ]
     },
     {
@@ -959,7 +1019,7 @@
       "title": "Verify product license and feature entitlement state",
       "summary": "Confirm product, version, validity, edition, and required feature without exposing license data.",
       "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.html",
-      "when_to_use": "Use for trial, license validation, edition, and feature-denied events.",
+      "when_to_use": "Use for trial or registered-status, license-validation, edition, and feature-denied events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -976,23 +1036,23 @@
           "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
-          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
+          "expected": "For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.",
+          "failure": "For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data."
         },
         {
-          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
+          "instruction": "For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.",
           "commands": [],
-          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "expected": "For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.",
           "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
+      "verification": "For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
@@ -1055,7 +1115,7 @@
       "title": "Verify service state, dependencies, and service account",
       "summary": "Confirm service state, start mode, dependencies, account, and SCM errors.",
       "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/service-verify-state-and-account.html",
-      "when_to_use": "Use for service startup, shutdown, permission, and monitoring events.",
+      "when_to_use": "Use for service startup, shutdown, removal, permission, and monitoring events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -1084,15 +1144,15 @@
           "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
+          "instruction": "After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.",
           "commands": [],
-          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
-          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
+          "expected": "For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
+      "verification": "Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -3920,7 +3980,7 @@
       "title": "A sender connection was refused by the permitted-senders limit",
       "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
+      "meaning": "The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.",
       "likely_causes": [
         "Permitted Senders is enabled and the configured number of sender entries is already in use.",
         "The connecting sender is not one of the currently permitted senders.",
@@ -3946,9 +4006,9 @@
       ],
       "procedures": [
         {
-          "id": "license.verify-license-state",
-          "title": "Verify product license and feature entitlement state",
-          "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.html"
+          "id": "license.repair-permitted-senders-configuration",
+          "title": "Repair the permitted-senders configuration",
+          "url": "https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/winsyslog/event-ids.json
+++ b/source/_generated/event-ids/winsyslog/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "3ee9a9b50f5d94487221416de7b536a172b2d816",
+  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
   "product": "winsyslog",
   "product_name": "WinSyslog",
   "product_version": "26.07",
@@ -25,32 +25,35 @@
         {
           "instruction": "Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.",
+          "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
           "commands": [
+            "Get-Date -Format o",
+            "w32tm /query /status",
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The output contains the first product failure and later state or recovery events.",
-          "failure": "Increase the bounded time window and verify the Event Log source shown on the Event ID page."
+          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
+        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -220,33 +223,36 @@
       ],
       "steps": [
         {
-          "instruction": "Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.",
+          "instruction": "Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "A readable pre-change export exists and its modification time precedes the troubleshooting change.",
+          "failure": "Do not continue with a state-changing repair until a readable pre-change export exists."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.",
           "commands": [
+            "$captureStart=Get-Date; $captureStart.ToString('o')",
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime",
-            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime"
+            "Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime",
+            "$captureEnd=Get-Date; $captureEnd.ToString('o')"
           ],
-          "expected": "Both files exist, are readable, and cover the recorded reproduction interval.",
-          "failure": "Verify the service account can write the debug directory and restart only if the setting requires it."
+          "expected": "The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.",
+          "failure": "Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.",
+          "failure": "Repeat only after correcting the capture window; do not collect an unbounded debug log."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
-        "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "The capture start and end timestamps, complete Event Log entry, and neighboring product events.",
+        "The pre-change configuration export and bounded debug log from the same interval.",
+        "Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -465,24 +471,24 @@
       ],
       "steps": [
         {
-          "instruction": "Export the configuration and open the exact service, rule, filter, or action named in the event.",
+          "instruction": "Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The event detail and Configuration Client identify the same object and a readable pre-change export exists.",
+          "failure": "Do not infer the object from its type alone; collect the complete event and configuration export first."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.",
           "commands": [
             "Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime"
           ],
-          "expected": "A readable pre-change backup exists and all required fields reference valid product objects.",
-          "failure": "Restore the export if the edited configuration cannot load; do not copy objects from another product manual."
+          "expected": "Every required reference resolves to an existing object and every selected feature is available in this product and edition.",
+          "failure": "Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.",
           "commands": [],
           "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "failure": "Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects."
         }
       ],
       "repair_steps": [],
@@ -490,7 +496,7 @@
         "Restore the configuration export created before the change.",
         "Reload the restored configuration and verify the previous behavior."
       ],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -966,30 +972,31 @@
         {
           "instruction": "Record product version, displayed license status, edition, and feature named in the event without copying the license payload.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.",
+          "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The signed license targets the running product/version and includes the configured feature.",
-          "failure": "Install the authorized license or disable unsupported configuration; never edit signed data."
+          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
+          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
-        "The command output, relevant configuration export, and bounded debug log from the same interval."
+        "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
+        "A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -1061,28 +1068,31 @@
         {
           "instruction": "Identify the internal Windows service name and intended service account.",
           "commands": [],
-          "expected": "The affected object and its effective settings are identified.",
-          "failure": "Return to the complete Event Log detail and configuration export before changing settings."
+          "expected": "The internal service name and intended account are known before any start, stop, or account change.",
+          "failure": "Use the service Properties dialog or the command output below; do not guess the internal name."
         },
         {
-          "instruction": "Run the native Windows checks below from the affected product host.",
+          "instruction": "Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.",
           "commands": [
-            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,State,StartMode,StartName,ExitCode",
-            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType"
+            "Get-CimInstance Win32_Service -Filter \"Name='<SERVICE_NAME>'\" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode",
+            "Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType",
+            "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
+            "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
+            "Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The service and required dependencies are in the intended state under the intended account.",
-          "failure": "Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure."
+          "expected": "The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.",
+          "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "Perform one uniquely identifiable product test through the same service, rule, or action.",
+          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
           "commands": [],
-          "expected": "The intended destination records the test exactly once.",
-          "failure": "Collect the first new product event and bounded debug output; do not change unrelated settings."
+          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
+      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -1223,18 +1233,17 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service was installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was installed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was installed.",
       "meaning": "The Windows service registration completed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product installation or explicit service-install operation registered the Windows service."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service installation was intended.",
+        "If the registration was unexpected, identify the installation or administrative action that occurred at the same time.",
+        "Verify the registered service name, executable path, start mode, and service account before starting it."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the intended service registration and that the service can enter the Running state.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1271,18 +1280,17 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service was removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was removed. Additional detail: {event_detail}",
+      "message_pattern": "The {service_name} service was removed.",
       "meaning": "The Windows service registration was removed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A product uninstall or explicit service-remove operation deleted the Windows service registration."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when service removal was intended.",
+        "If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.",
+        "Reinstall the service only after confirming that the product files and configuration should remain on this system."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1319,18 +1327,19 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service could not be removed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service could not be removed. Additional detail: {event_detail}",
-      "meaning": "The Windows service remains registered.",
+      "message_pattern": "The {service_name} service could not be removed.",
+      "meaning": "Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The account performing removal lacks permission to delete the service.",
+        "The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.",
+        "The service name or registration state changed during removal."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.",
+        "Confirm the current service registration and whether Windows already marked the service for deletion.",
+        "Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1367,18 +1376,19 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service control handler could not be installed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service control handler could not be installed. Additional detail: {event_detail}",
-      "meaning": "Windows cannot deliver normal service control requests to the process.",
+      "message_pattern": "The control handler could not be installed.",
+      "meaning": "The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The executable was started outside the Service Control Manager instead of as the registered Windows service.",
+        "Windows rejected handler registration because the service process or registration state is invalid.",
+        "A Windows service-control failure occurred during very early startup."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Start the product through Windows Services or Start-Service, not by launching the service executable interactively.",
+        "Check neighboring Service Control Manager events and the registered executable path.",
+        "Repair the product installation if the service registration points to the wrong executable, then perform one controlled start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1415,18 +1425,19 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service initialization process failed",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service initialization process failed. Additional detail: {event_detail}",
-      "meaning": "The product service did not start.",
+      "message_pattern": "The initialization process failed.",
+      "meaning": "Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.",
+        "The service account cannot access a required file, registry key, network resource, provider, or certificate.",
+        "A required Windows resource or product component failed during initialization."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.",
+        "Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.",
+        "Correct only the specific earlier failure, then perform one controlled service start."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1463,18 +1474,17 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service was started",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was started. Additional detail: {event_detail}",
+      "message_pattern": "The service was started.",
       "meaning": "The product service entered its running state.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows started the product service and product initialization completed successfully."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the start was intended.",
+        "If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.",
+        "Verify one configured input and destination instead of relying on service state alone."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that the service remains Running and processes one identifiable event through the intended destination.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1511,18 +1521,18 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service received an unsupported control request",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service received an unsupported control request. Additional detail: {event_detail}",
-      "meaning": "The requested Windows service-control operation was not performed.",
+      "message_pattern": "The service received an unsupported request.",
+      "meaning": "Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "A management tool or script sent a control code that the product does not support.",
+        "A monitoring or service-management integration used the wrong control operation."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.",
+        "Change the caller to use supported start, stop, or other documented service operations.",
+        "Confirm that the service remains in its intended state after removing the unsupported request."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Run the corrected management operation and confirm the intended service state without Event ID 106.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1559,18 +1569,17 @@
       "event_source": "AdisconWinSyslog",
       "title": "The service was stopped",
       "component": "Windows service lifecycle",
-      "message_pattern": "The service was stopped. Additional detail: {event_detail}",
+      "message_pattern": "The service was stopped.",
       "meaning": "The product service completed shutdown.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "Windows, an administrator, an installer, or product shutdown logic requested an orderly stop."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "No repair is required when the stop was intended.",
+        "If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.",
+        "Distinguish this orderly stop from a process termination or crash before changing configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.",
+      "success_verification": "Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1605,20 +1614,20 @@
       "event_id": 118,
       "severity": "information",
       "event_source": "AdisconWinSyslog",
-      "title": "Trial mode reminder",
+      "title": "Product license status reminder",
       "component": "Licensing",
-      "message_pattern": "The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}",
-      "meaning": "Trial limits and expiration apply to the running product.",
+      "message_pattern": "The product reports its trial or registered license mode. Additional detail: {license_status_detail}",
+      "meaning": "The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The service started in trial mode and reports the remaining evaluation period.",
+        "The service started with a valid license and reports the active registered edition."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Read the complete event detail to distinguish trial mode from registered mode.",
+        "No repair is required when the reported mode and edition are expected.",
+        "If the mode is unexpected, compare the running product and version with the displayed license status without copying license data."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service remains Running and that the reported license mode matches the intended product and edition.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1658,15 +1667,15 @@
       "message_pattern": "WinSyslog is running in freeware mode; the event detail describes the active limitation. Additional detail: {event_detail}",
       "meaning": "Freeware-mode limits apply to the running WinSyslog service.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The WinSyslog trial expired and the installed version permits continued operation in Free Edition mode.",
+        "No registered WinSyslog license is active, so Free Edition limits apply."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "No repair is required when Free Edition mode is intended.",
+        "Review the active Free Edition limits before relying on additional senders or licensed features.",
+        "If registered operation is intended, install the authorized WinSyslog license and restart the service."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 125 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that WinSyslog reports the intended Free Edition or registered mode and processes one event within that edition's limits.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1706,15 +1715,15 @@
       "message_pattern": "WinSyslog rejected an invalid license key during startup. Additional detail: {event_detail}",
       "meaning": "The WinSyslog service does not start with the rejected key.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The installed key is invalid, altered, or not issued for this WinSyslog product and version.",
+        "License material was copied incompletely or placed in the wrong product configuration."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running WinSyslog version and displayed license status without copying or editing the key.",
+        "Replace the rejected material with the authorized license issued for this product and version.",
+        "Start WinSyslog once and verify the reported license mode."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 900 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that WinSyslog reaches Running, reports the intended licensed mode, and does not emit Event ID 900 during startup.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -1754,15 +1763,15 @@
       "message_pattern": "The product rejected a blocked license key during startup. Additional detail: {event_detail}",
       "meaning": "The product service does not start with the blocked key.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The installed key is on the product's blocked-key list and cannot authorize startup.",
+        "License material intended for a different or superseded installation is still configured."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Do not modify or repeatedly re-enter the blocked key.",
+        "Confirm the exact product and version, then obtain and install authorized replacement license material.",
+        "Start the service once and verify the reported license mode."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 901 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the service reaches Running, reports the intended licensed mode, and does not emit Event ID 901 during startup.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -2090,17 +2099,18 @@
       "title": "Configured feature is not licensed",
       "component": "Licensing",
       "message_pattern": "A configured module is not covered by the signed license feature entitlements. Additional detail: {event_detail}",
-      "meaning": "The module or option is not loaded at startup.",
+      "meaning": "The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "The configuration enables a module that is not included in the installed edition or license.",
+        "A configuration copied from another product or edition contains a feature that is unavailable here.",
+        "The installed signed license does not match the intended product, version, or feature set."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the module kind, module name, and required feature identifier from the complete event detail.",
+        "Confirm the running product, version, edition, and displayed license status without copying the license payload.",
+        "Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.",
+      "success_verification": "Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -4051,20 +4061,21 @@
       "event_id": 11043,
       "severity": "error",
       "event_source": "AdisconWinSyslog",
-      "title": "Licensing: connection attempt failed",
-      "component": "Licensing",
+      "title": "A sender connection was refused by the permitted-senders limit",
+      "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "Permitted Senders is enabled and the configured number of sender entries is already in use.",
+        "The connecting sender is not one of the currently permitted senders.",
+        "The permitted-senders configuration no longer matches the intended sender inventory."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.",
+        "Review the current permitted-senders entries and remove only entries that are confirmed obsolete.",
+        "If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -4099,20 +4110,21 @@
       "event_id": 11044,
       "severity": "error",
       "event_source": "AdisconWinSyslog",
-      "title": "Licensing: licensed client limit exceeded",
-      "component": "Licensing",
+      "title": "A sender connection exceeded the licensed client limit",
+      "component": "Client connection licensing",
       "message_pattern": "Client license limit exceeded. Additional detail: {event_detail}",
-      "meaning": "Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.",
+      "meaning": "The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.",
       "likely_causes": [
-        "The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.",
-        "Windows or a required provider returned the operation-specific error appended to the event."
+        "More distinct senders are connecting than the installed edition or license permits.",
+        "A changed sender address causes an existing device to be counted as an additional client.",
+        "The installed license is not the intended license for this product or system."
       ],
       "immediate_checks": [
-        "Identify the exact service, rule, filter, action, or setting named by the complete event detail.",
-        "Compare that object with the product reference and preserve the first related error in the same time window.",
-        "Correct only the identified setting or dependency, then run one controlled test."
+        "Confirm the running product, edition, displayed license status, and client allowance without copying license data.",
+        "Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.",
+        "Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.",
+      "success_verification": "Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -11095,20 +11107,20 @@
       "event_id": 11186,
       "severity": "error",
       "event_source": "AdisconWinSyslog",
-      "title": "Service configuration: trial period expired",
-      "component": "Service configuration",
-      "message_pattern": "Servicemanager. Additional detail: {event_detail}",
-      "meaning": "Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.",
+      "title": "The trial expired and the service was disabled",
+      "component": "Licensing",
+      "message_pattern": "ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}",
+      "meaning": "The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.",
       "likely_causes": [
-        "The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.",
-        "Windows returned the appended startup, shutdown, permission, timeout, or resource error."
+        "The evaluation period expired and no valid product license is installed.",
+        "The installed license is invalid for the running product or version."
       ],
       "immediate_checks": [
-        "Record the affected service or component, service account, state, dependencies, and complete runtime detail.",
-        "Check recent Service Control Manager and neighboring product events for the first failure.",
-        "Correct the specific dependency, account, permission, or resource condition and perform one controlled retry."
+        "Confirm the exact product, version, and displayed license state without copying license data.",
+        "Install the authorized license for this product and version; do not edit signed license content.",
+        "Start the service and verify that its configured inputs load and process one controlled test."
       ],
-      "success_verification": "Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.",
+      "success_verification": "Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.",
       "evidence_to_collect": [
         "The complete Windows Application Event Log entry, including all event detail.",
         "The product name, exact version, service account, and event timestamp with time zone.",
@@ -11123,9 +11135,9 @@
       ],
       "procedures": [
         {
-          "id": "config.validate-and-reload",
-          "title": "Validate configuration and reload it safely",
-          "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/config-validate-and-reload.html"
+          "id": "license.verify-license-state",
+          "title": "Verify product license and feature entitlement state",
+          "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/_generated/event-ids/winsyslog/event-ids.json
+++ b/source/_generated/event-ids/winsyslog/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "7b77bacbd5b91724bebfed41e923a0348270250f",
+  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
   "product": "winsyslog",
   "product_name": "WinSyslog",
   "product_version": "26.07",

--- a/source/_generated/event-ids/winsyslog/event-ids.json
+++ b/source/_generated/event-ids/winsyslog/event-ids.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 2,
   "catalog_status": "ready",
-  "source_commit": "b1d024ddc253bc74690a0d2af326e9015b3772e2",
+  "source_commit": "6303266429db09363d7bd37e35db26ebff443b90",
   "product": "winsyslog",
   "product_name": "WinSyslog",
   "product_version": "26.07",
@@ -29,16 +29,23 @@
           "failure": "Export the original event as an EVTX file before copying text or changing filters."
         },
         {
-          "instruction": "Record the host clock state, then collect only the product events in a bounded window around the event.",
+          "instruction": "For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.",
           "commands": [
             "Get-Date -Format o",
-            "w32tm /query /status",
+            "w32tm /query /status"
+          ],
+          "expected": "Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.",
+          "failure": "If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture."
+        },
+        {
+          "instruction": "On the affected product host, collect only the product events in a bounded window around the event.",
+          "commands": [
             "$start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)",
             "$end=(Get-Date '<EVENT_TIME>').AddMinutes(5)",
             "Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message"
           ],
-          "expected": "The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.",
-          "failure": "Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event."
+          "expected": "The event sequence contains the first failure plus any later state or recovery event.",
+          "failure": "Verify the provider shown on the Event ID page and expand the window only enough to include the first related event."
         },
         {
           "instruction": "After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.",
@@ -52,8 +59,8 @@
       "verification": "Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.",
       "evidence_to_collect": [
         "The original EVTX record plus the complete rendered event and neighboring product events with timestamps.",
-        "Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.",
-        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed."
+        "Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.",
+        "The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings."
       ],
       "optional_tools": [],
       "related_procedures": []
@@ -305,6 +312,59 @@
       "optional_tools": [],
       "related_procedures": [
         "evidence.collect-event-and-neighboring-events"
+      ]
+    },
+    {
+      "id": "license.repair-permitted-senders-configuration",
+      "title": "Repair the permitted-senders configuration",
+      "summary": "Authorize an intended sender without weakening the sender restriction.",
+      "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html",
+      "when_to_use": "Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.",
+      "prerequisites": [
+        "Use an account that can read and update the affected product configuration.",
+        "Replace angle-bracket placeholders with values from the affected system."
+      ],
+      "safety": [
+        "Do not disable permitted-senders protection solely to accept a sender.",
+        "Do not publish sender addresses or a full configuration export."
+      ],
+      "steps": [
+        {
+          "instruction": "Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.",
+          "commands": [],
+          "expected": "The intended sender and the active permitted-sender positions are known.",
+          "failure": "Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list."
+        },
+        {
+          "instruction": "Compare the intended sender inventory with the configured count and active entry order.",
+          "commands": [],
+          "expected": "Each required sender is present within the active permitted-sender range.",
+          "failure": "Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection."
+        },
+        {
+          "instruction": "If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.",
+          "commands": [],
+          "expected": "The intended sender is authorized without admitting unapproved senders.",
+          "failure": "Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process."
+        },
+        {
+          "instruction": "Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.",
+          "commands": [],
+          "expected": "The product accepts the test exactly once and Event ID 11043 does not recur.",
+          "failure": "Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary."
+        }
+      ],
+      "repair_steps": [],
+      "rollback_steps": [],
+      "verification": "Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.",
+      "evidence_to_collect": [
+        "The complete Event ID 11043 entry and neighboring product events with timestamps.",
+        "A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.",
+        "The product version and non-secret license allowance when the intended inventory exceeds the configured count."
+      ],
+      "optional_tools": [],
+      "related_procedures": [
+        "license.verify-license-state"
       ]
     },
     {
@@ -959,7 +1019,7 @@
       "title": "Verify product license and feature entitlement state",
       "summary": "Confirm product, version, validity, edition, and required feature without exposing license data.",
       "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.html",
-      "when_to_use": "Use for trial, license validation, edition, and feature-denied events.",
+      "when_to_use": "Use for trial or registered-status, license-validation, edition, and feature-denied events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -976,23 +1036,23 @@
           "failure": "Do not copy the license file or key; record only the product UI's status and non-secret version information."
         },
         {
-          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.",
+          "instruction": "Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.",
           "commands": [
             "Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion"
           ],
-          "expected": "The authorized license targets the running product and version and includes the required feature or sufficient client capacity.",
-          "failure": "Install authorized replacement license material or disable the unsupported configuration; never edit signed data."
+          "expected": "For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.",
+          "failure": "For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data."
         },
         {
-          "instruction": "Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.",
+          "instruction": "For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.",
           "commands": [],
-          "expected": "The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.",
+          "expected": "For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.",
           "failure": "Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.",
+      "verification": "For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.",
@@ -1055,7 +1115,7 @@
       "title": "Verify service state, dependencies, and service account",
       "summary": "Confirm service state, start mode, dependencies, account, and SCM errors.",
       "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/service-verify-state-and-account.html",
-      "when_to_use": "Use for service startup, shutdown, permission, and monitoring events.",
+      "when_to_use": "Use for service startup, shutdown, removal, permission, and monitoring events.",
       "prerequisites": [
         "Use an account that can read the product configuration and Windows diagnostic state.",
         "Replace angle-bracket placeholders with values from the affected system."
@@ -1084,15 +1144,15 @@
           "failure": "Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure."
         },
         {
-          "instruction": "After correcting the specific startup condition, start the service once and perform one identifiable product test.",
+          "instruction": "After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.",
           "commands": [],
-          "expected": "The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.",
-          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from that start attempt."
+          "expected": "For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.",
+          "failure": "Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation."
         }
       ],
       "repair_steps": [],
       "rollback_steps": [],
-      "verification": "Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.",
+      "verification": "Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.",
       "evidence_to_collect": [
         "The complete Event Log entry and neighboring product events with timestamps.",
         "The command output, relevant configuration export, and bounded debug log from the same interval."
@@ -4064,7 +4124,7 @@
       "title": "A sender connection was refused by the permitted-senders limit",
       "component": "Client connection licensing",
       "message_pattern": "Connection refused. Additional detail: {event_detail}",
-      "meaning": "The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.",
+      "meaning": "The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.",
       "likely_causes": [
         "Permitted Senders is enabled and the configured number of sender entries is already in use.",
         "The connecting sender is not one of the currently permitted senders.",
@@ -4090,9 +4150,9 @@
       ],
       "procedures": [
         {
-          "id": "license.verify-license-state",
-          "title": "Verify product license and feature entitlement state",
-          "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.html"
+          "id": "license.repair-permitted-senders-configuration",
+          "title": "Repair the permitted-senders configuration",
+          "url": "https://www.winsyslog.com/files/manual/current/winsyslogspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.html"
         },
         {
           "id": "evidence.collect-event-and-neighboring-events",

--- a/source/eventreporterspecific/event-id-reference/event-id-100.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-100.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product installation or explicit service-install operation registered the Windows service.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service installation was intended.
+#. If the registration was unexpected, identify the installation or administrative action that occurred at the same time.
+#. Verify the registered service name, executable path, start mode, and service account before starting it.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the intended service registration and that the service can enter the Running state.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-101.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-101.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product uninstall or explicit service-remove operation deleted the Windows service registration.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service removal was intended.
+#. If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.
+#. Reinstall the service only after confirming that the product files and configuration should remain on this system.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-102.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-102.rst
@@ -16,7 +16,7 @@ EventReporter Event ID 102: The service could not be removed
 Answer
 ------
 
-The Windows service remains registered.
+Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service could not be removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service could not be removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The account performing removal lacks permission to delete the service.
+- The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.
+- The service name or registration state changed during removal.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.
+#. Confirm the current service registration and whether Windows already marked the service for deletion.
+#. Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-103.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-103.rst
@@ -16,7 +16,7 @@ EventReporter Event ID 103: The service control handler could not be installed
 Answer
 ------
 
-Windows cannot deliver normal service control requests to the process.
+The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service control handler could not be installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The control handler could not be installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The executable was started outside the Service Control Manager instead of as the registered Windows service.
+- Windows rejected handler registration because the service process or registration state is invalid.
+- A Windows service-control failure occurred during very early startup.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Start the product through Windows Services or Start-Service, not by launching the service executable interactively.
+#. Check neighboring Service Control Manager events and the registered executable path.
+#. Repair the product installation if the service registration points to the wrong executable, then perform one controlled start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-104.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-104.rst
@@ -16,7 +16,7 @@ EventReporter Event ID 104: The service initialization process failed
 Answer
 ------
 
-The product service did not start.
+Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service initialization process failed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The initialization process failed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.
+- The service account cannot access a required file, registry key, network resource, provider, or certificate.
+- A required Windows resource or product component failed during initialization.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.
+#. Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.
+#. Correct only the specific earlier failure, then perform one controlled service start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.
+Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-105.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-105.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was started. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was started.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows started the product service and product initialization completed successfully.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the start was intended.
+#. If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.
+#. Verify one configured input and destination instead of relying on service state alone.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.
+Confirm that the service remains Running and processes one identifiable event through the intended destination.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-106.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-106.rst
@@ -16,7 +16,7 @@ EventReporter Event ID 106: The service received an unsupported control request
 Answer
 ------
 
-The requested Windows service-control operation was not performed.
+Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service received an unsupported control request. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service received an unsupported request.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A management tool or script sent a control code that the product does not support.
+- A monitoring or service-management integration used the wrong control operation.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.
+#. Change the caller to use supported start, stop, or other documented service operations.
+#. Confirm that the service remains in its intended state after removing the unsupported request.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.
+Run the corrected management operation and confirm the intended service state without Event ID 106.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-108.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-108.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was stopped. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was stopped.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows, an administrator, an installer, or product shutdown logic requested an orderly stop.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the stop was intended.
+#. If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.
+#. Distinguish this orderly stop from a process termination or crash before changing configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.
+Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-11005.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-11005.rst
@@ -16,7 +16,7 @@ EventReporter Event ID 11005: Configured feature is not licensed
 Answer
 ------
 
-The module or option is not loaded at startup.
+The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.
 
 Event details
 -------------
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The configuration enables a module that is not included in the installed edition or license.
+- A configuration copied from another product or edition contains a feature that is unavailable here.
+- The installed signed license does not match the intended product, version, or feature set.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the module kind, module name, and required feature identifier from the complete event detail.
+#. Confirm the running product, version, edition, and displayed license status without copying the license payload.
+#. Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.
+Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-11043.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-11043.rst
@@ -3,27 +3,27 @@
 .. _eventreporter-event-id-11043:
 
 .. meta::
-   :description: Meaning and troubleshooting for EventReporter Event ID 11043: Licensing: connection attempt failed.
+   :description: Meaning and troubleshooting for EventReporter Event ID 11043: A sender connection was refused by the permitted-senders limit.
    :event-id: 11043
    :event-product: EventReporter
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-EventReporter Event ID 11043: Licensing: connection attempt failed
-==================================================================
+EventReporter Event ID 11043: A sender connection was refused by the permitted-senders limit
+============================================================================================
 
 Answer
 ------
 
-Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
 
 Event details
 -------------
 
 - **Event ID:** ``11043``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Connection refused. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- Permitted Senders is enabled and the configured number of sender entries is already in use.
+- The connecting sender is not one of the currently permitted senders.
+- The permitted-senders configuration no longer matches the intended sender inventory.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.
+#. Review the current permitted-senders entries and remove only entries that are confirmed obsolete.
+#. If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.
+Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-11043.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-11043.rst
@@ -16,7 +16,7 @@ EventReporter Event ID 11043: A sender connection was refused by the permitted-s
 Answer
 ------
 
-The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
+The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.
 
 Event details
 -------------
@@ -45,7 +45,7 @@ Immediate checks
 Detailed procedures
 -------------------
 
-- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 

--- a/source/eventreporterspecific/event-id-reference/event-id-11044.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-11044.rst
@@ -3,27 +3,27 @@
 .. _eventreporter-event-id-11044:
 
 .. meta::
-   :description: Meaning and troubleshooting for EventReporter Event ID 11044: Licensing: licensed client limit exceeded.
+   :description: Meaning and troubleshooting for EventReporter Event ID 11044: A sender connection exceeded the licensed client limit.
    :event-id: 11044
    :event-product: EventReporter
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-EventReporter Event ID 11044: Licensing: licensed client limit exceeded
-=======================================================================
+EventReporter Event ID 11044: A sender connection exceeded the licensed client limit
+====================================================================================
 
 Answer
 ------
 
-Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.
 
 Event details
 -------------
 
 - **Event ID:** ``11044``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Client license limit exceeded. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- More distinct senders are connecting than the installed edition or license permits.
+- A changed sender address causes an existing device to be counted as an additional client.
+- The installed license is not the intended license for this product or system.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Confirm the running product, edition, displayed license status, and client allowance without copying license data.
+#. Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.
+#. Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.
+Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-11186.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-11186.rst
@@ -3,55 +3,55 @@
 .. _eventreporter-event-id-11186:
 
 .. meta::
-   :description: Meaning and troubleshooting for EventReporter Event ID 11186: Service configuration: trial period expired.
+   :description: Meaning and troubleshooting for EventReporter Event ID 11186: The trial expired and the service was disabled.
    :event-id: 11186
    :event-product: EventReporter
    :event-severity: Error
-   :event-component: Service configuration
+   :event-component: Licensing
    :event-reference: true
 
-EventReporter Event ID 11186: Service configuration: trial period expired
-=========================================================================
+EventReporter Event ID 11186: The trial expired and the service was disabled
+============================================================================
 
 Answer
 ------
 
-Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.
+The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.
 
 Event details
 -------------
 
 - **Event ID:** ``11186``
 - **Severity:** Error
-- **Component:** Service configuration
+- **Component:** Licensing
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** 26.07
-- **Message pattern:** :spelling:ignore:`Servicemanager. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The evaluation period expired and no valid product license is installed.
+- The installed license is invalid for the running product or version.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Confirm the exact product, version, and displayed license state without copying license data.
+#. Install the authorized license for this product and version; do not edit signed license content.
+#. Start the service and verify that its configured inputs load and process one controlled test.
 
 Detailed procedures
 -------------------
 
-- :ref:`Validate configuration and reload it safely <event-id-procedure-config-validate-and-reload>` — Back up, inspect, correct, and test the exact invalid configuration object.
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.
+Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-118.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-118.rst
@@ -3,20 +3,20 @@
 .. _eventreporter-event-id-118:
 
 .. meta::
-   :description: Meaning and troubleshooting for EventReporter Event ID 118: Trial mode reminder.
+   :description: Meaning and troubleshooting for EventReporter Event ID 118: Product license status reminder.
    :event-id: 118
    :event-product: EventReporter
    :event-severity: Information
    :event-component: Licensing
    :event-reference: true
 
-EventReporter Event ID 118: Trial mode reminder
-===============================================
+EventReporter Event ID 118: Product license status reminder
+===========================================================
 
 Answer
 ------
 
-Trial limits and expiration apply to the running product.
+The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Licensing
 - **Windows Event Log source:** ``Adiscon EvntSLog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The product reports its trial or registered license mode. Additional detail: {license_status_detail}`
 
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The service started in trial mode and reports the remaining evaluation period.
+- The service started with a valid license and reports the active registered edition.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Read the complete event detail to distinguish trial mode from registered mode.
+#. No repair is required when the reported mode and edition are expected.
+#. If the mode is unexpected, compare the running product and version with the displayed license status without copying license data.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.
+Confirm that the service remains Running and that the reported license mode matches the intended product and edition.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/event-id-901.rst
+++ b/source/eventreporterspecific/event-id-reference/event-id-901.rst
@@ -31,15 +31,15 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The installed key is on the product's blocked-key list and cannot authorize startup.
+- License material intended for a different or superseded installation is still configured.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Do not modify or repeatedly re-enter the blocked key.
+#. Confirm the exact product and version, then obtain and install authorized replacement license material.
+#. Start the service once and verify the reported license mode.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 901 does not recur and that licensing processing continues.
+Confirm that the service reaches Running, reports the intended licensed mode, and does not emit Event ID 901 during startup.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/index.rst
+++ b/source/eventreporterspecific/event-id-reference/index.rst
@@ -73,7 +73,7 @@ Event ID index
      - Information
      - Windows service lifecycle
    * - :ref:`118 <eventreporter-event-id-118>`
-     - Trial mode reminder
+     - Product license status reminder
      - Information
      - Licensing
    * - :ref:`901 <eventreporter-event-id-901>`
@@ -253,13 +253,13 @@ Event ID index
      - Error
      - Write to File action
    * - :ref:`11043 <eventreporter-event-id-11043>`
-     - Licensing: connection attempt failed
+     - A sender connection was refused by the permitted-senders limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11044 <eventreporter-event-id-11044>`
-     - Licensing: licensed client limit exceeded
+     - A sender connection exceeded the licensed client limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11045 <eventreporter-event-id-11045>`
      - File-based configuration: file-based configuration could not be loaded
      - Error
@@ -821,9 +821,9 @@ Event ID index
      - Error
      - Service configuration
    * - :ref:`11186 <eventreporter-event-id-11186>`
-     - Service configuration: trial period expired
+     - The trial expired and the service was disabled
      - Error
-     - Service configuration
+     - Licensing
    * - :ref:`11187 <eventreporter-event-id-11187>`
      - A configured input service type is not recognized
      - Error

--- a/source/eventreporterspecific/event-id-reference/procedure/config-validate-and-reload.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/config-validate-and-reload.rst
@@ -40,27 +40,27 @@ Configuration Client > the service, rule, or action named on the Event ID page.
 Procedure
 ---------
 
-#. Export the configuration and open the exact service, rule, filter, or action named in the event.
+#. Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The event detail and Configuration Client identify the same object and a readable pre-change export exists.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not infer the object from its type alone; collect the complete event and configuration export first.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
 
-   **Expected result:** A readable pre-change backup exists and all required fields reference valid product objects.
+   **Expected result:** Every required reference resolves to an existing object and every selected feature is available in this product and edition.
 
-   **If it fails:** Restore the export if the edited configuration cannot load; do not copy objects from another product manual.
+   **If it fails:** Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects.
 
 Rollback
 --------
@@ -71,7 +71,7 @@ Rollback
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.
 
 Evidence to collect
 -------------------
@@ -107,7 +107,6 @@ Related Event IDs
 - :ref:`EventReporter Event ID 11183 <eventreporter-event-id-11183>`
 - :ref:`EventReporter Event ID 11184 <eventreporter-event-id-11184>`
 - :ref:`EventReporter Event ID 11185 <eventreporter-event-id-11185>`
-- :ref:`EventReporter Event ID 11186 <eventreporter-event-id-11186>`
 - :ref:`EventReporter Event ID 11187 <eventreporter-event-id-11187>`
 - :ref:`EventReporter Event ID 11189 <eventreporter-event-id-11189>`
 - :ref:`EventReporter Event ID 11191 <eventreporter-event-id-11191>`

--- a/source/eventreporterspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -42,27 +42,29 @@ Procedure
 
 #. Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the host clock state, then collect only the product events in a bounded window around the event.
 
    .. code-block:: powershell
 
+      Get-Date -Format o
+      w32tm /query /status
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The output contains the first product failure and later state or recovery events.
+   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Increase the bounded time window and verify the Event Log source shown on the Event ID page.
+   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings.
 
 Verify the result
 -----------------
@@ -72,8 +74,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
+- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
 
 Related Event IDs
 -----------------

--- a/source/eventreporterspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -46,19 +46,28 @@ Procedure
 
    **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Record the host clock state, then collect only the product events in a bounded window around the event.
+#. For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.
 
    .. code-block:: powershell
 
       Get-Date -Format o
       w32tm /query /status
+
+   **Expected result:** Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.
+
+   **If it fails:** If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture.
+
+#. On the affected product host, collect only the product events in a bounded window around the event.
+
+   .. code-block:: powershell
+
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
+   **Expected result:** The event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
+   **If it fails:** Verify the provider shown on the Event ID page and expand the window only enough to include the first related event.
 
 #. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
@@ -75,8 +84,8 @@ Evidence to collect
 -------------------
 
 - The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
-- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
-- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
+- Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings.
 
 Related Event IDs
 -----------------

--- a/source/eventreporterspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
@@ -40,28 +40,30 @@ Configuration Client > Computer > Export Settings to Registry File; then General
 Procedure
 ---------
 
-#. Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.
+#. Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** A readable pre-change export exists and its modification time precedes the troubleshooting change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not continue with a state-changing repair until a readable pre-change export exists.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.
 
    .. code-block:: powershell
 
+      $captureStart=Get-Date; $captureStart.ToString('o')
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
       Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime
+      $captureEnd=Get-Date; $captureEnd.ToString('o')
 
-   **Expected result:** Both files exist, are readable, and cover the recorded reproduction interval.
+   **Expected result:** The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.
 
-   **If it fails:** Verify the service account can write the debug directory and restart only if the setting requires it.
+   **If it fails:** Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Repeat only after correcting the capture window; do not collect an unbounded debug log.
 
 Verify the result
 -----------------
@@ -71,8 +73,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The capture start and end timestamps, complete Event Log entry, and neighboring product events.
+- The pre-change configuration export and bounded debug log from the same interval.
+- Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed.
 
 Related Event IDs
 -----------------

--- a/source/eventreporterspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
@@ -1,0 +1,88 @@
+:orphan:
+
+.. _event-id-procedure-license-repair-permitted-senders-configuration:
+
+.. meta::
+   :description: Authorize an intended sender without weakening the sender restriction.
+   :procedure-id: license.repair-permitted-senders-configuration
+   :procedure-reference: true
+
+Repair the permitted-senders configuration
+==========================================
+
+When to use this procedure
+--------------------------
+
+Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.
+
+Applies to
+----------
+
+This procedure applies to EventReporter.
+
+Prerequisites
+-------------
+
+- Use an account that can read and update the affected product configuration.
+- Replace angle-bracket placeholders with values from the affected system.
+
+Safety
+------
+
+- Do not disable permitted-senders protection solely to accept a sender.
+- Do not publish sender addresses or a full configuration export.
+
+Configuration path
+------------------
+
+Configuration Client > General > permitted-senders settings.
+
+Procedure
+---------
+
+#. Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.
+
+   **Expected result:** The intended sender and the active permitted-sender positions are known.
+
+   **If it fails:** Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list.
+
+#. Compare the intended sender inventory with the configured count and active entry order.
+
+   **Expected result:** Each required sender is present within the active permitted-sender range.
+
+   **If it fails:** Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection.
+
+#. If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.
+
+   **Expected result:** The intended sender is authorized without admitting unapproved senders.
+
+   **If it fails:** Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process.
+
+#. Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.
+
+   **Expected result:** The product accepts the test exactly once and Event ID 11043 does not recur.
+
+   **If it fails:** Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary.
+
+Verify the result
+-----------------
+
+Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.
+
+Evidence to collect
+-------------------
+
+- The complete Event ID 11043 entry and neighboring product events with timestamps.
+- A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.
+- The product version and non-secret license allowance when the intended inventory exceeds the configured count.
+
+Related Event IDs
+-----------------
+
+- :ref:`EventReporter Event ID 11043 <eventreporter-event-id-11043>`
+
+
+Related procedures
+------------------
+
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>`

--- a/source/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -42,36 +42,37 @@ Procedure
 
 #. Record product version, displayed license status, edition, and feature named in the event without copying the license payload.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The signed license targets the running product/version and includes the configured feature.
+   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
 
-   **If it fails:** Install the authorized license or disable unsupported configuration; never edit signed data.
+   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
 
 Evidence to collect
 -------------------
 
 - The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.
+- A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers.
 
 Related Event IDs
 -----------------
@@ -81,3 +82,4 @@ Related Event IDs
 - :ref:`EventReporter Event ID 11005 <eventreporter-event-id-11005>`
 - :ref:`EventReporter Event ID 11043 <eventreporter-event-id-11043>`
 - :ref:`EventReporter Event ID 11044 <eventreporter-event-id-11044>`
+- :ref:`EventReporter Event ID 11186 <eventreporter-event-id-11186>`

--- a/source/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -13,7 +13,7 @@ Verify product license and feature entitlement state
 When to use this procedure
 --------------------------
 
-Use for trial, license validation, edition, and feature-denied events.
+Use for trial or registered-status, license-validation, edition, and feature-denied events.
 
 Applies to
 ----------
@@ -46,26 +46,26 @@ Procedure
 
    **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
+   **Expected result:** For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.
 
-   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
+   **If it fails:** For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data.
 
-#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
+#. For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.
 
-   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
+   **Expected result:** For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.
 
    **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
+For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.
 
 Evidence to collect
 -------------------
@@ -80,6 +80,5 @@ Related Event IDs
 - :ref:`EventReporter Event ID 118 <eventreporter-event-id-118>`
 - :ref:`EventReporter Event ID 901 <eventreporter-event-id-901>`
 - :ref:`EventReporter Event ID 11005 <eventreporter-event-id-11005>`
-- :ref:`EventReporter Event ID 11043 <eventreporter-event-id-11043>`
 - :ref:`EventReporter Event ID 11044 <eventreporter-event-id-11044>`
 - :ref:`EventReporter Event ID 11186 <eventreporter-event-id-11186>`

--- a/source/eventreporterspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -42,31 +42,34 @@ Procedure
 
 #. Identify the internal Windows service name and intended service account.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The internal service name and intended account are known before any start, stop, or account change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Use the service Properties dialog or the command output below; do not guess the internal name.
 
-#. Run the native Windows checks below from the affected product host.
+#. Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.
 
    .. code-block:: powershell
 
-      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,State,StartMode,StartName,ExitCode
+      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode
       Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType
+      $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
+      $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
+      Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The service and required dependencies are in the intended state under the intended account.
+   **Expected result:** The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.
 
-   **If it fails:** Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure.
+   **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/eventreporterspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -13,7 +13,7 @@ Verify service state, dependencies, and service account
 When to use this procedure
 --------------------------
 
-Use for service startup, shutdown, permission, and monitoring events.
+Use for service startup, shutdown, removal, permission, and monitoring events.
 
 Applies to
 ----------
@@ -60,16 +60,16 @@ Procedure
 
    **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
+#. After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.
 
-   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
+   **Expected result:** For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.
 
-   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation.
 
 Verify the result
 -----------------
 
-Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
+Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.
 
 Evidence to collect
 -------------------

--- a/source/eventreporterspecific/event-id-reference/procedures.rst
+++ b/source/eventreporterspecific/event-id-reference/procedures.rst
@@ -15,6 +15,7 @@ expected results, failure branches, recovery verification, and evidence collecti
 - :ref:`Diagnose log rotation and retention <event-id-procedure-file-diagnose-log-rotation>` — Verify trigger, names, handles, destination access, and retention.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 - :ref:`Interpret a Windows or Winsock error code <event-id-procedure-windows-interpret-error-code>` — Translate a numeric code without losing its operation or subsystem context.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Resolve a destination and test its TCP port <event-id-procedure-network-resolve-host-and-test-tcp-port>` — Verify DNS, selected address, routing, and TCP establishment.
 - :ref:`Test an ODBC connection in the product context <event-id-procedure-database-test-odbc-connection>` — Verify ODBC provider, architecture, authentication, connectivity, and a minimal query.
 - :ref:`Test an OLE DB connection in the product context <event-id-procedure-database-test-oledb-connection>` — Verify OLE DB provider, architecture, authentication, connectivity, and a minimal query.

--- a/source/mwagentspecific/event-id-reference/event-id-100.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-100.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product installation or explicit service-install operation registered the Windows service.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service installation was intended.
+#. If the registration was unexpected, identify the installation or administrative action that occurred at the same time.
+#. Verify the registered service name, executable path, start mode, and service account before starting it.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the intended service registration and that the service can enter the Running state.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-101.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-101.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product uninstall or explicit service-remove operation deleted the Windows service registration.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service removal was intended.
+#. If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.
+#. Reinstall the service only after confirming that the product files and configuration should remain on this system.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-102.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-102.rst
@@ -16,7 +16,7 @@ MonitorWare Agent Event ID 102: The service could not be removed
 Answer
 ------
 
-The Windows service remains registered.
+Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service could not be removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service could not be removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The account performing removal lacks permission to delete the service.
+- The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.
+- The service name or registration state changed during removal.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.
+#. Confirm the current service registration and whether Windows already marked the service for deletion.
+#. Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-103.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-103.rst
@@ -16,7 +16,7 @@ MonitorWare Agent Event ID 103: The service control handler could not be install
 Answer
 ------
 
-Windows cannot deliver normal service control requests to the process.
+The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service control handler could not be installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The control handler could not be installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The executable was started outside the Service Control Manager instead of as the registered Windows service.
+- Windows rejected handler registration because the service process or registration state is invalid.
+- A Windows service-control failure occurred during very early startup.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Start the product through Windows Services or Start-Service, not by launching the service executable interactively.
+#. Check neighboring Service Control Manager events and the registered executable path.
+#. Repair the product installation if the service registration points to the wrong executable, then perform one controlled start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-104.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-104.rst
@@ -16,7 +16,7 @@ MonitorWare Agent Event ID 104: The service initialization process failed
 Answer
 ------
 
-The product service did not start.
+Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service initialization process failed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The initialization process failed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.
+- The service account cannot access a required file, registry key, network resource, provider, or certificate.
+- A required Windows resource or product component failed during initialization.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.
+#. Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.
+#. Correct only the specific earlier failure, then perform one controlled service start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.
+Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-105.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-105.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was started. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was started.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows started the product service and product initialization completed successfully.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the start was intended.
+#. If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.
+#. Verify one configured input and destination instead of relying on service state alone.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.
+Confirm that the service remains Running and processes one identifiable event through the intended destination.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-106.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-106.rst
@@ -16,7 +16,7 @@ MonitorWare Agent Event ID 106: The service received an unsupported control requ
 Answer
 ------
 
-The requested Windows service-control operation was not performed.
+Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service received an unsupported control request. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service received an unsupported request.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A management tool or script sent a control code that the product does not support.
+- A monitoring or service-management integration used the wrong control operation.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.
+#. Change the caller to use supported start, stop, or other documented service operations.
+#. Confirm that the service remains in its intended state after removing the unsupported request.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.
+Run the corrected management operation and confirm the intended service state without Event ID 106.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-108.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-108.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was stopped. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was stopped.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows, an administrator, an installer, or product shutdown logic requested an orderly stop.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the stop was intended.
+#. If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.
+#. Distinguish this orderly stop from a process termination or crash before changing configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.
+Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-11005.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-11005.rst
@@ -16,7 +16,7 @@ MonitorWare Agent Event ID 11005: Configured feature is not licensed
 Answer
 ------
 
-The module or option is not loaded at startup.
+The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.
 
 Event details
 -------------
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The configuration enables a module that is not included in the installed edition or license.
+- A configuration copied from another product or edition contains a feature that is unavailable here.
+- The installed signed license does not match the intended product, version, or feature set.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the module kind, module name, and required feature identifier from the complete event detail.
+#. Confirm the running product, version, edition, and displayed license status without copying the license payload.
+#. Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.
+Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-11043.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-11043.rst
@@ -3,27 +3,27 @@
 .. _mwagent-event-id-11043:
 
 .. meta::
-   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 11043: Licensing: connection attempt failed.
+   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 11043: A sender connection was refused by the permitted-senders limit.
    :event-id: 11043
    :event-product: MonitorWare Agent
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-MonitorWare Agent Event ID 11043: Licensing: connection attempt failed
-======================================================================
+MonitorWare Agent Event ID 11043: A sender connection was refused by the permitted-senders limit
+================================================================================================
 
 Answer
 ------
 
-Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
 
 Event details
 -------------
 
 - **Event ID:** ``11043``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Connection refused. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- Permitted Senders is enabled and the configured number of sender entries is already in use.
+- The connecting sender is not one of the currently permitted senders.
+- The permitted-senders configuration no longer matches the intended sender inventory.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.
+#. Review the current permitted-senders entries and remove only entries that are confirmed obsolete.
+#. If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.
+Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-11043.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-11043.rst
@@ -16,7 +16,7 @@ MonitorWare Agent Event ID 11043: A sender connection was refused by the permitt
 Answer
 ------
 
-The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
+The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.
 
 Event details
 -------------
@@ -45,7 +45,7 @@ Immediate checks
 Detailed procedures
 -------------------
 
-- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 

--- a/source/mwagentspecific/event-id-reference/event-id-11044.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-11044.rst
@@ -3,27 +3,27 @@
 .. _mwagent-event-id-11044:
 
 .. meta::
-   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 11044: Licensing: licensed client limit exceeded.
+   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 11044: A sender connection exceeded the licensed client limit.
    :event-id: 11044
    :event-product: MonitorWare Agent
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-MonitorWare Agent Event ID 11044: Licensing: licensed client limit exceeded
-===========================================================================
+MonitorWare Agent Event ID 11044: A sender connection exceeded the licensed client limit
+========================================================================================
 
 Answer
 ------
 
-Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.
 
 Event details
 -------------
 
 - **Event ID:** ``11044``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Client license limit exceeded. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- More distinct senders are connecting than the installed edition or license permits.
+- A changed sender address causes an existing device to be counted as an additional client.
+- The installed license is not the intended license for this product or system.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Confirm the running product, edition, displayed license status, and client allowance without copying license data.
+#. Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.
+#. Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.
+Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-11186.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-11186.rst
@@ -3,55 +3,55 @@
 .. _mwagent-event-id-11186:
 
 .. meta::
-   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 11186: Service configuration: trial period expired.
+   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 11186: The trial expired and the service was disabled.
    :event-id: 11186
    :event-product: MonitorWare Agent
    :event-severity: Error
-   :event-component: Service configuration
+   :event-component: Licensing
    :event-reference: true
 
-MonitorWare Agent Event ID 11186: Service configuration: trial period expired
-=============================================================================
+MonitorWare Agent Event ID 11186: The trial expired and the service was disabled
+================================================================================
 
 Answer
 ------
 
-Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.
+The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.
 
 Event details
 -------------
 
 - **Event ID:** ``11186``
 - **Severity:** Error
-- **Component:** Service configuration
+- **Component:** Licensing
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** 26.07
-- **Message pattern:** :spelling:ignore:`Servicemanager. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The evaluation period expired and no valid product license is installed.
+- The installed license is invalid for the running product or version.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Confirm the exact product, version, and displayed license state without copying license data.
+#. Install the authorized license for this product and version; do not edit signed license content.
+#. Start the service and verify that its configured inputs load and process one controlled test.
 
 Detailed procedures
 -------------------
 
-- :ref:`Validate configuration and reload it safely <event-id-procedure-config-validate-and-reload>` — Back up, inspect, correct, and test the exact invalid configuration object.
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.
+Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/event-id-118.rst
+++ b/source/mwagentspecific/event-id-reference/event-id-118.rst
@@ -3,20 +3,20 @@
 .. _mwagent-event-id-118:
 
 .. meta::
-   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 118: Trial mode reminder.
+   :description: Meaning and troubleshooting for MonitorWare Agent Event ID 118: Product license status reminder.
    :event-id: 118
    :event-product: MonitorWare Agent
    :event-severity: Information
    :event-component: Licensing
    :event-reference: true
 
-MonitorWare Agent Event ID 118: Trial mode reminder
-===================================================
+MonitorWare Agent Event ID 118: Product license status reminder
+===============================================================
 
 Answer
 ------
 
-Trial limits and expiration apply to the running product.
+The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Licensing
 - **Windows Event Log source:** ``AdisconMonitoreWareAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The product reports its trial or registered license mode. Additional detail: {license_status_detail}`
 
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The service started in trial mode and reports the remaining evaluation period.
+- The service started with a valid license and reports the active registered edition.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Read the complete event detail to distinguish trial mode from registered mode.
+#. No repair is required when the reported mode and edition are expected.
+#. If the mode is unexpected, compare the running product and version with the displayed license status without copying license data.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.
+Confirm that the service remains Running and that the reported license mode matches the intended product and edition.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/index.rst
+++ b/source/mwagentspecific/event-id-reference/index.rst
@@ -73,7 +73,7 @@ Event ID index
      - Information
      - Windows service lifecycle
    * - :ref:`118 <mwagent-event-id-118>`
-     - Trial mode reminder
+     - Product license status reminder
      - Information
      - Licensing
    * - :ref:`11000 <mwagent-event-id-11000>`
@@ -249,13 +249,13 @@ Event ID index
      - Error
      - Write to File action
    * - :ref:`11043 <mwagent-event-id-11043>`
-     - Licensing: connection attempt failed
+     - A sender connection was refused by the permitted-senders limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11044 <mwagent-event-id-11044>`
-     - Licensing: licensed client limit exceeded
+     - A sender connection exceeded the licensed client limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11045 <mwagent-event-id-11045>`
      - File-based configuration: file-based configuration could not be loaded
      - Error
@@ -817,9 +817,9 @@ Event ID index
      - Error
      - Service configuration
    * - :ref:`11186 <mwagent-event-id-11186>`
-     - Service configuration: trial period expired
+     - The trial expired and the service was disabled
      - Error
-     - Service configuration
+     - Licensing
    * - :ref:`11187 <mwagent-event-id-11187>`
      - A configured input service type is not recognized
      - Error

--- a/source/mwagentspecific/event-id-reference/procedure/config-validate-and-reload.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/config-validate-and-reload.rst
@@ -40,27 +40,27 @@ Configuration Client > the service, rule, or action named on the Event ID page.
 Procedure
 ---------
 
-#. Export the configuration and open the exact service, rule, filter, or action named in the event.
+#. Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The event detail and Configuration Client identify the same object and a readable pre-change export exists.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not infer the object from its type alone; collect the complete event and configuration export first.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
 
-   **Expected result:** A readable pre-change backup exists and all required fields reference valid product objects.
+   **Expected result:** Every required reference resolves to an existing object and every selected feature is available in this product and edition.
 
-   **If it fails:** Restore the export if the edited configuration cannot load; do not copy objects from another product manual.
+   **If it fails:** Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects.
 
 Rollback
 --------
@@ -71,7 +71,7 @@ Rollback
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.
 
 Evidence to collect
 -------------------
@@ -107,7 +107,6 @@ Related Event IDs
 - :ref:`MonitorWare Agent Event ID 11183 <mwagent-event-id-11183>`
 - :ref:`MonitorWare Agent Event ID 11184 <mwagent-event-id-11184>`
 - :ref:`MonitorWare Agent Event ID 11185 <mwagent-event-id-11185>`
-- :ref:`MonitorWare Agent Event ID 11186 <mwagent-event-id-11186>`
 - :ref:`MonitorWare Agent Event ID 11187 <mwagent-event-id-11187>`
 - :ref:`MonitorWare Agent Event ID 11189 <mwagent-event-id-11189>`
 - :ref:`MonitorWare Agent Event ID 11191 <mwagent-event-id-11191>`

--- a/source/mwagentspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -42,27 +42,29 @@ Procedure
 
 #. Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the host clock state, then collect only the product events in a bounded window around the event.
 
    .. code-block:: powershell
 
+      Get-Date -Format o
+      w32tm /query /status
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The output contains the first product failure and later state or recovery events.
+   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Increase the bounded time window and verify the Event Log source shown on the Event ID page.
+   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings.
 
 Verify the result
 -----------------
@@ -72,8 +74,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
+- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
 
 Related Event IDs
 -----------------

--- a/source/mwagentspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -46,19 +46,28 @@ Procedure
 
    **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Record the host clock state, then collect only the product events in a bounded window around the event.
+#. For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.
 
    .. code-block:: powershell
 
       Get-Date -Format o
       w32tm /query /status
+
+   **Expected result:** Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.
+
+   **If it fails:** If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture.
+
+#. On the affected product host, collect only the product events in a bounded window around the event.
+
+   .. code-block:: powershell
+
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
+   **Expected result:** The event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
+   **If it fails:** Verify the provider shown on the Event ID page and expand the window only enough to include the first related event.
 
 #. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
@@ -75,8 +84,8 @@ Evidence to collect
 -------------------
 
 - The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
-- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
-- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
+- Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings.
 
 Related Event IDs
 -----------------

--- a/source/mwagentspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
@@ -40,28 +40,30 @@ Configuration Client > Computer > Export Settings to Registry File; then General
 Procedure
 ---------
 
-#. Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.
+#. Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** A readable pre-change export exists and its modification time precedes the troubleshooting change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not continue with a state-changing repair until a readable pre-change export exists.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.
 
    .. code-block:: powershell
 
+      $captureStart=Get-Date; $captureStart.ToString('o')
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
       Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime
+      $captureEnd=Get-Date; $captureEnd.ToString('o')
 
-   **Expected result:** Both files exist, are readable, and cover the recorded reproduction interval.
+   **Expected result:** The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.
 
-   **If it fails:** Verify the service account can write the debug directory and restart only if the setting requires it.
+   **If it fails:** Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Repeat only after correcting the capture window; do not collect an unbounded debug log.
 
 Verify the result
 -----------------
@@ -71,8 +73,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The capture start and end timestamps, complete Event Log entry, and neighboring product events.
+- The pre-change configuration export and bounded debug log from the same interval.
+- Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed.
 
 Related Event IDs
 -----------------

--- a/source/mwagentspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
@@ -1,0 +1,88 @@
+:orphan:
+
+.. _event-id-procedure-license-repair-permitted-senders-configuration:
+
+.. meta::
+   :description: Authorize an intended sender without weakening the sender restriction.
+   :procedure-id: license.repair-permitted-senders-configuration
+   :procedure-reference: true
+
+Repair the permitted-senders configuration
+==========================================
+
+When to use this procedure
+--------------------------
+
+Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.
+
+Applies to
+----------
+
+This procedure applies to MonitorWare Agent.
+
+Prerequisites
+-------------
+
+- Use an account that can read and update the affected product configuration.
+- Replace angle-bracket placeholders with values from the affected system.
+
+Safety
+------
+
+- Do not disable permitted-senders protection solely to accept a sender.
+- Do not publish sender addresses or a full configuration export.
+
+Configuration path
+------------------
+
+Configuration Client > General > permitted-senders settings.
+
+Procedure
+---------
+
+#. Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.
+
+   **Expected result:** The intended sender and the active permitted-sender positions are known.
+
+   **If it fails:** Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list.
+
+#. Compare the intended sender inventory with the configured count and active entry order.
+
+   **Expected result:** Each required sender is present within the active permitted-sender range.
+
+   **If it fails:** Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection.
+
+#. If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.
+
+   **Expected result:** The intended sender is authorized without admitting unapproved senders.
+
+   **If it fails:** Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process.
+
+#. Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.
+
+   **Expected result:** The product accepts the test exactly once and Event ID 11043 does not recur.
+
+   **If it fails:** Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary.
+
+Verify the result
+-----------------
+
+Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.
+
+Evidence to collect
+-------------------
+
+- The complete Event ID 11043 entry and neighboring product events with timestamps.
+- A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.
+- The product version and non-secret license allowance when the intended inventory exceeds the configured count.
+
+Related Event IDs
+-----------------
+
+- :ref:`MonitorWare Agent Event ID 11043 <mwagent-event-id-11043>`
+
+
+Related procedures
+------------------
+
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>`

--- a/source/mwagentspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -42,36 +42,37 @@ Procedure
 
 #. Record product version, displayed license status, edition, and feature named in the event without copying the license payload.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The signed license targets the running product/version and includes the configured feature.
+   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
 
-   **If it fails:** Install the authorized license or disable unsupported configuration; never edit signed data.
+   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
 
 Evidence to collect
 -------------------
 
 - The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.
+- A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers.
 
 Related Event IDs
 -----------------
@@ -80,3 +81,4 @@ Related Event IDs
 - :ref:`MonitorWare Agent Event ID 11005 <mwagent-event-id-11005>`
 - :ref:`MonitorWare Agent Event ID 11043 <mwagent-event-id-11043>`
 - :ref:`MonitorWare Agent Event ID 11044 <mwagent-event-id-11044>`
+- :ref:`MonitorWare Agent Event ID 11186 <mwagent-event-id-11186>`

--- a/source/mwagentspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -13,7 +13,7 @@ Verify product license and feature entitlement state
 When to use this procedure
 --------------------------
 
-Use for trial, license validation, edition, and feature-denied events.
+Use for trial or registered-status, license-validation, edition, and feature-denied events.
 
 Applies to
 ----------
@@ -46,26 +46,26 @@ Procedure
 
    **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
+   **Expected result:** For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.
 
-   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
+   **If it fails:** For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data.
 
-#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
+#. For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.
 
-   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
+   **Expected result:** For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.
 
    **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
+For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.
 
 Evidence to collect
 -------------------
@@ -79,6 +79,5 @@ Related Event IDs
 
 - :ref:`MonitorWare Agent Event ID 118 <mwagent-event-id-118>`
 - :ref:`MonitorWare Agent Event ID 11005 <mwagent-event-id-11005>`
-- :ref:`MonitorWare Agent Event ID 11043 <mwagent-event-id-11043>`
 - :ref:`MonitorWare Agent Event ID 11044 <mwagent-event-id-11044>`
 - :ref:`MonitorWare Agent Event ID 11186 <mwagent-event-id-11186>`

--- a/source/mwagentspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -42,31 +42,34 @@ Procedure
 
 #. Identify the internal Windows service name and intended service account.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The internal service name and intended account are known before any start, stop, or account change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Use the service Properties dialog or the command output below; do not guess the internal name.
 
-#. Run the native Windows checks below from the affected product host.
+#. Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.
 
    .. code-block:: powershell
 
-      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,State,StartMode,StartName,ExitCode
+      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode
       Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType
+      $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
+      $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
+      Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The service and required dependencies are in the intended state under the intended account.
+   **Expected result:** The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.
 
-   **If it fails:** Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure.
+   **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/mwagentspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -13,7 +13,7 @@ Verify service state, dependencies, and service account
 When to use this procedure
 --------------------------
 
-Use for service startup, shutdown, permission, and monitoring events.
+Use for service startup, shutdown, removal, permission, and monitoring events.
 
 Applies to
 ----------
@@ -60,16 +60,16 @@ Procedure
 
    **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
+#. After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.
 
-   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
+   **Expected result:** For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.
 
-   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation.
 
 Verify the result
 -----------------
 
-Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
+Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.
 
 Evidence to collect
 -------------------

--- a/source/mwagentspecific/event-id-reference/procedures.rst
+++ b/source/mwagentspecific/event-id-reference/procedures.rst
@@ -15,6 +15,7 @@ expected results, failure branches, recovery verification, and evidence collecti
 - :ref:`Diagnose log rotation and retention <event-id-procedure-file-diagnose-log-rotation>` — Verify trigger, names, handles, destination access, and retention.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 - :ref:`Interpret a Windows or Winsock error code <event-id-procedure-windows-interpret-error-code>` — Translate a numeric code without losing its operation or subsystem context.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Resolve a destination and test its TCP port <event-id-procedure-network-resolve-host-and-test-tcp-port>` — Verify DNS, selected address, routing, and TCP establishment.
 - :ref:`Test an ODBC connection in the product context <event-id-procedure-database-test-odbc-connection>` — Verify ODBC provider, architecture, authentication, connectivity, and a minimal query.
 - :ref:`Test an OLE DB connection in the product context <event-id-procedure-database-test-oledb-connection>` — Verify OLE DB provider, architecture, authentication, connectivity, and a minimal query.

--- a/source/rsyslogwaspecific/event-id-reference/event-id-100.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-100.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product installation or explicit service-install operation registered the Windows service.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service installation was intended.
+#. If the registration was unexpected, identify the installation or administrative action that occurred at the same time.
+#. Verify the registered service name, executable path, start mode, and service account before starting it.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the intended service registration and that the service can enter the Running state.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-101.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-101.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product uninstall or explicit service-remove operation deleted the Windows service registration.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service removal was intended.
+#. If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.
+#. Reinstall the service only after confirming that the product files and configuration should remain on this system.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-102.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-102.rst
@@ -16,7 +16,7 @@ rsyslog Windows Agent Event ID 102: The service could not be removed
 Answer
 ------
 
-The Windows service remains registered.
+Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service could not be removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service could not be removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The account performing removal lacks permission to delete the service.
+- The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.
+- The service name or registration state changed during removal.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.
+#. Confirm the current service registration and whether Windows already marked the service for deletion.
+#. Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-103.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-103.rst
@@ -16,7 +16,7 @@ rsyslog Windows Agent Event ID 103: The service control handler could not be ins
 Answer
 ------
 
-Windows cannot deliver normal service control requests to the process.
+The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service control handler could not be installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The control handler could not be installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The executable was started outside the Service Control Manager instead of as the registered Windows service.
+- Windows rejected handler registration because the service process or registration state is invalid.
+- A Windows service-control failure occurred during very early startup.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Start the product through Windows Services or Start-Service, not by launching the service executable interactively.
+#. Check neighboring Service Control Manager events and the registered executable path.
+#. Repair the product installation if the service registration points to the wrong executable, then perform one controlled start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-104.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-104.rst
@@ -16,7 +16,7 @@ rsyslog Windows Agent Event ID 104: The service initialization process failed
 Answer
 ------
 
-The product service did not start.
+Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service initialization process failed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The initialization process failed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.
+- The service account cannot access a required file, registry key, network resource, provider, or certificate.
+- A required Windows resource or product component failed during initialization.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.
+#. Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.
+#. Correct only the specific earlier failure, then perform one controlled service start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.
+Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-105.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-105.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was started. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was started.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows started the product service and product initialization completed successfully.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the start was intended.
+#. If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.
+#. Verify one configured input and destination instead of relying on service state alone.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.
+Confirm that the service remains Running and processes one identifiable event through the intended destination.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-106.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-106.rst
@@ -16,7 +16,7 @@ rsyslog Windows Agent Event ID 106: The service received an unsupported control 
 Answer
 ------
 
-The requested Windows service-control operation was not performed.
+Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service received an unsupported control request. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service received an unsupported request.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A management tool or script sent a control code that the product does not support.
+- A monitoring or service-management integration used the wrong control operation.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.
+#. Change the caller to use supported start, stop, or other documented service operations.
+#. Confirm that the service remains in its intended state after removing the unsupported request.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.
+Run the corrected management operation and confirm the intended service state without Event ID 106.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-108.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-108.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was stopped. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was stopped.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows, an administrator, an installer, or product shutdown logic requested an orderly stop.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the stop was intended.
+#. If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.
+#. Distinguish this orderly stop from a process termination or crash before changing configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.
+Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-11005.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-11005.rst
@@ -16,7 +16,7 @@ rsyslog Windows Agent Event ID 11005: Configured feature is not licensed
 Answer
 ------
 
-The module or option is not loaded at startup.
+The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.
 
 Event details
 -------------
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The configuration enables a module that is not included in the installed edition or license.
+- A configuration copied from another product or edition contains a feature that is unavailable here.
+- The installed signed license does not match the intended product, version, or feature set.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the module kind, module name, and required feature identifier from the complete event detail.
+#. Confirm the running product, version, edition, and displayed license status without copying the license payload.
+#. Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.
+Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-11043.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-11043.rst
@@ -3,27 +3,27 @@
 .. _rsyslog-event-id-11043:
 
 .. meta::
-   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 11043: Licensing: connection attempt failed.
+   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 11043: A sender connection was refused by the permitted-senders limit.
    :event-id: 11043
    :event-product: rsyslog Windows Agent
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-rsyslog Windows Agent Event ID 11043: Licensing: connection attempt failed
-==========================================================================
+rsyslog Windows Agent Event ID 11043: A sender connection was refused by the permitted-senders limit
+====================================================================================================
 
 Answer
 ------
 
-Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
 
 Event details
 -------------
 
 - **Event ID:** ``11043``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Connection refused. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- Permitted Senders is enabled and the configured number of sender entries is already in use.
+- The connecting sender is not one of the currently permitted senders.
+- The permitted-senders configuration no longer matches the intended sender inventory.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.
+#. Review the current permitted-senders entries and remove only entries that are confirmed obsolete.
+#. If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.
+Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-11043.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-11043.rst
@@ -16,7 +16,7 @@ rsyslog Windows Agent Event ID 11043: A sender connection was refused by the per
 Answer
 ------
 
-The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
+The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.
 
 Event details
 -------------
@@ -45,7 +45,7 @@ Immediate checks
 Detailed procedures
 -------------------
 
-- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 

--- a/source/rsyslogwaspecific/event-id-reference/event-id-11044.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-11044.rst
@@ -3,27 +3,27 @@
 .. _rsyslog-event-id-11044:
 
 .. meta::
-   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 11044: Licensing: licensed client limit exceeded.
+   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 11044: A sender connection exceeded the licensed client limit.
    :event-id: 11044
    :event-product: rsyslog Windows Agent
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-rsyslog Windows Agent Event ID 11044: Licensing: licensed client limit exceeded
-===============================================================================
+rsyslog Windows Agent Event ID 11044: A sender connection exceeded the licensed client limit
+============================================================================================
 
 Answer
 ------
 
-Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.
 
 Event details
 -------------
 
 - **Event ID:** ``11044``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Client license limit exceeded. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- More distinct senders are connecting than the installed edition or license permits.
+- A changed sender address causes an existing device to be counted as an additional client.
+- The installed license is not the intended license for this product or system.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Confirm the running product, edition, displayed license status, and client allowance without copying license data.
+#. Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.
+#. Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.
+Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-11186.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-11186.rst
@@ -3,55 +3,55 @@
 .. _rsyslog-event-id-11186:
 
 .. meta::
-   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 11186: Service configuration: trial period expired.
+   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 11186: The trial expired and the service was disabled.
    :event-id: 11186
    :event-product: rsyslog Windows Agent
    :event-severity: Error
-   :event-component: Service configuration
+   :event-component: Licensing
    :event-reference: true
 
-rsyslog Windows Agent Event ID 11186: Service configuration: trial period expired
-=================================================================================
+rsyslog Windows Agent Event ID 11186: The trial expired and the service was disabled
+====================================================================================
 
 Answer
 ------
 
-Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.
+The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.
 
 Event details
 -------------
 
 - **Event ID:** ``11186``
 - **Severity:** Error
-- **Component:** Service configuration
+- **Component:** Licensing
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** 26.07
-- **Message pattern:** :spelling:ignore:`Servicemanager. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The evaluation period expired and no valid product license is installed.
+- The installed license is invalid for the running product or version.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Confirm the exact product, version, and displayed license state without copying license data.
+#. Install the authorized license for this product and version; do not edit signed license content.
+#. Start the service and verify that its configured inputs load and process one controlled test.
 
 Detailed procedures
 -------------------
 
-- :ref:`Validate configuration and reload it safely <event-id-procedure-config-validate-and-reload>` — Back up, inspect, correct, and test the exact invalid configuration object.
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.
+Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/event-id-118.rst
+++ b/source/rsyslogwaspecific/event-id-reference/event-id-118.rst
@@ -3,20 +3,20 @@
 .. _rsyslog-event-id-118:
 
 .. meta::
-   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 118: Trial mode reminder.
+   :description: Meaning and troubleshooting for rsyslog Windows Agent Event ID 118: Product license status reminder.
    :event-id: 118
    :event-product: rsyslog Windows Agent
    :event-severity: Information
    :event-component: Licensing
    :event-reference: true
 
-rsyslog Windows Agent Event ID 118: Trial mode reminder
-=======================================================
+rsyslog Windows Agent Event ID 118: Product license status reminder
+===================================================================
 
 Answer
 ------
 
-Trial limits and expiration apply to the running product.
+The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Licensing
 - **Windows Event Log source:** ``RSyslogWindowsAgent``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The product reports its trial or registered license mode. Additional detail: {license_status_detail}`
 
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The service started in trial mode and reports the remaining evaluation period.
+- The service started with a valid license and reports the active registered edition.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Read the complete event detail to distinguish trial mode from registered mode.
+#. No repair is required when the reported mode and edition are expected.
+#. If the mode is unexpected, compare the running product and version with the displayed license status without copying license data.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.
+Confirm that the service remains Running and that the reported license mode matches the intended product and edition.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/index.rst
+++ b/source/rsyslogwaspecific/event-id-reference/index.rst
@@ -73,7 +73,7 @@ Event ID index
      - Information
      - Windows service lifecycle
    * - :ref:`118 <rsyslog-event-id-118>`
-     - Trial mode reminder
+     - Product license status reminder
      - Information
      - Licensing
    * - :ref:`11000 <rsyslog-event-id-11000>`
@@ -249,13 +249,13 @@ Event ID index
      - Error
      - Write to File action
    * - :ref:`11043 <rsyslog-event-id-11043>`
-     - Licensing: connection attempt failed
+     - A sender connection was refused by the permitted-senders limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11044 <rsyslog-event-id-11044>`
-     - Licensing: licensed client limit exceeded
+     - A sender connection exceeded the licensed client limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11045 <rsyslog-event-id-11045>`
      - File-based configuration: file-based configuration could not be loaded
      - Error
@@ -817,9 +817,9 @@ Event ID index
      - Error
      - Service configuration
    * - :ref:`11186 <rsyslog-event-id-11186>`
-     - Service configuration: trial period expired
+     - The trial expired and the service was disabled
      - Error
-     - Service configuration
+     - Licensing
    * - :ref:`11187 <rsyslog-event-id-11187>`
      - A configured input service type is not recognized
      - Error

--- a/source/rsyslogwaspecific/event-id-reference/procedure/config-validate-and-reload.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/config-validate-and-reload.rst
@@ -40,27 +40,27 @@ Configuration Client > the service, rule, or action named on the Event ID page.
 Procedure
 ---------
 
-#. Export the configuration and open the exact service, rule, filter, or action named in the event.
+#. Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The event detail and Configuration Client identify the same object and a readable pre-change export exists.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not infer the object from its type alone; collect the complete event and configuration export first.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
 
-   **Expected result:** A readable pre-change backup exists and all required fields reference valid product objects.
+   **Expected result:** Every required reference resolves to an existing object and every selected feature is available in this product and edition.
 
-   **If it fails:** Restore the export if the edited configuration cannot load; do not copy objects from another product manual.
+   **If it fails:** Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects.
 
 Rollback
 --------
@@ -71,7 +71,7 @@ Rollback
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.
 
 Evidence to collect
 -------------------
@@ -107,7 +107,6 @@ Related Event IDs
 - :ref:`rsyslog Windows Agent Event ID 11183 <rsyslog-event-id-11183>`
 - :ref:`rsyslog Windows Agent Event ID 11184 <rsyslog-event-id-11184>`
 - :ref:`rsyslog Windows Agent Event ID 11185 <rsyslog-event-id-11185>`
-- :ref:`rsyslog Windows Agent Event ID 11186 <rsyslog-event-id-11186>`
 - :ref:`rsyslog Windows Agent Event ID 11187 <rsyslog-event-id-11187>`
 - :ref:`rsyslog Windows Agent Event ID 11189 <rsyslog-event-id-11189>`
 - :ref:`rsyslog Windows Agent Event ID 11191 <rsyslog-event-id-11191>`

--- a/source/rsyslogwaspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -42,27 +42,29 @@ Procedure
 
 #. Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the host clock state, then collect only the product events in a bounded window around the event.
 
    .. code-block:: powershell
 
+      Get-Date -Format o
+      w32tm /query /status
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The output contains the first product failure and later state or recovery events.
+   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Increase the bounded time window and verify the Event Log source shown on the Event ID page.
+   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings.
 
 Verify the result
 -----------------
@@ -72,8 +74,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
+- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
 
 Related Event IDs
 -----------------

--- a/source/rsyslogwaspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -46,19 +46,28 @@ Procedure
 
    **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Record the host clock state, then collect only the product events in a bounded window around the event.
+#. For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.
 
    .. code-block:: powershell
 
       Get-Date -Format o
       w32tm /query /status
+
+   **Expected result:** Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.
+
+   **If it fails:** If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture.
+
+#. On the affected product host, collect only the product events in a bounded window around the event.
+
+   .. code-block:: powershell
+
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
+   **Expected result:** The event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
+   **If it fails:** Verify the provider shown on the Event ID page and expand the window only enough to include the first related event.
 
 #. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
@@ -75,8 +84,8 @@ Evidence to collect
 -------------------
 
 - The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
-- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
-- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
+- Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings.
 
 Related Event IDs
 -----------------

--- a/source/rsyslogwaspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
@@ -40,28 +40,30 @@ Configuration Client > Computer > Export Settings to Registry File; then General
 Procedure
 ---------
 
-#. Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.
+#. Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** A readable pre-change export exists and its modification time precedes the troubleshooting change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not continue with a state-changing repair until a readable pre-change export exists.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.
 
    .. code-block:: powershell
 
+      $captureStart=Get-Date; $captureStart.ToString('o')
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
       Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime
+      $captureEnd=Get-Date; $captureEnd.ToString('o')
 
-   **Expected result:** Both files exist, are readable, and cover the recorded reproduction interval.
+   **Expected result:** The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.
 
-   **If it fails:** Verify the service account can write the debug directory and restart only if the setting requires it.
+   **If it fails:** Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Repeat only after correcting the capture window; do not collect an unbounded debug log.
 
 Verify the result
 -----------------
@@ -71,8 +73,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The capture start and end timestamps, complete Event Log entry, and neighboring product events.
+- The pre-change configuration export and bounded debug log from the same interval.
+- Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed.
 
 Related Event IDs
 -----------------

--- a/source/rsyslogwaspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
@@ -1,0 +1,88 @@
+:orphan:
+
+.. _event-id-procedure-license-repair-permitted-senders-configuration:
+
+.. meta::
+   :description: Authorize an intended sender without weakening the sender restriction.
+   :procedure-id: license.repair-permitted-senders-configuration
+   :procedure-reference: true
+
+Repair the permitted-senders configuration
+==========================================
+
+When to use this procedure
+--------------------------
+
+Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.
+
+Applies to
+----------
+
+This procedure applies to rsyslog Windows Agent.
+
+Prerequisites
+-------------
+
+- Use an account that can read and update the affected product configuration.
+- Replace angle-bracket placeholders with values from the affected system.
+
+Safety
+------
+
+- Do not disable permitted-senders protection solely to accept a sender.
+- Do not publish sender addresses or a full configuration export.
+
+Configuration path
+------------------
+
+Configuration Client > General > permitted-senders settings.
+
+Procedure
+---------
+
+#. Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.
+
+   **Expected result:** The intended sender and the active permitted-sender positions are known.
+
+   **If it fails:** Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list.
+
+#. Compare the intended sender inventory with the configured count and active entry order.
+
+   **Expected result:** Each required sender is present within the active permitted-sender range.
+
+   **If it fails:** Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection.
+
+#. If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.
+
+   **Expected result:** The intended sender is authorized without admitting unapproved senders.
+
+   **If it fails:** Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process.
+
+#. Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.
+
+   **Expected result:** The product accepts the test exactly once and Event ID 11043 does not recur.
+
+   **If it fails:** Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary.
+
+Verify the result
+-----------------
+
+Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.
+
+Evidence to collect
+-------------------
+
+- The complete Event ID 11043 entry and neighboring product events with timestamps.
+- A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.
+- The product version and non-secret license allowance when the intended inventory exceeds the configured count.
+
+Related Event IDs
+-----------------
+
+- :ref:`rsyslog Windows Agent Event ID 11043 <rsyslog-event-id-11043>`
+
+
+Related procedures
+------------------
+
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>`

--- a/source/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -42,36 +42,37 @@ Procedure
 
 #. Record product version, displayed license status, edition, and feature named in the event without copying the license payload.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The signed license targets the running product/version and includes the configured feature.
+   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
 
-   **If it fails:** Install the authorized license or disable unsupported configuration; never edit signed data.
+   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
 
 Evidence to collect
 -------------------
 
 - The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.
+- A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers.
 
 Related Event IDs
 -----------------
@@ -80,3 +81,4 @@ Related Event IDs
 - :ref:`rsyslog Windows Agent Event ID 11005 <rsyslog-event-id-11005>`
 - :ref:`rsyslog Windows Agent Event ID 11043 <rsyslog-event-id-11043>`
 - :ref:`rsyslog Windows Agent Event ID 11044 <rsyslog-event-id-11044>`
+- :ref:`rsyslog Windows Agent Event ID 11186 <rsyslog-event-id-11186>`

--- a/source/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -13,7 +13,7 @@ Verify product license and feature entitlement state
 When to use this procedure
 --------------------------
 
-Use for trial, license validation, edition, and feature-denied events.
+Use for trial or registered-status, license-validation, edition, and feature-denied events.
 
 Applies to
 ----------
@@ -46,26 +46,26 @@ Procedure
 
    **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
+   **Expected result:** For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.
 
-   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
+   **If it fails:** For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data.
 
-#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
+#. For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.
 
-   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
+   **Expected result:** For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.
 
    **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
+For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.
 
 Evidence to collect
 -------------------
@@ -79,6 +79,5 @@ Related Event IDs
 
 - :ref:`rsyslog Windows Agent Event ID 118 <rsyslog-event-id-118>`
 - :ref:`rsyslog Windows Agent Event ID 11005 <rsyslog-event-id-11005>`
-- :ref:`rsyslog Windows Agent Event ID 11043 <rsyslog-event-id-11043>`
 - :ref:`rsyslog Windows Agent Event ID 11044 <rsyslog-event-id-11044>`
 - :ref:`rsyslog Windows Agent Event ID 11186 <rsyslog-event-id-11186>`

--- a/source/rsyslogwaspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -42,31 +42,34 @@ Procedure
 
 #. Identify the internal Windows service name and intended service account.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The internal service name and intended account are known before any start, stop, or account change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Use the service Properties dialog or the command output below; do not guess the internal name.
 
-#. Run the native Windows checks below from the affected product host.
+#. Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.
 
    .. code-block:: powershell
 
-      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,State,StartMode,StartName,ExitCode
+      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode
       Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType
+      $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
+      $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
+      Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The service and required dependencies are in the intended state under the intended account.
+   **Expected result:** The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.
 
-   **If it fails:** Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure.
+   **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -13,7 +13,7 @@ Verify service state, dependencies, and service account
 When to use this procedure
 --------------------------
 
-Use for service startup, shutdown, permission, and monitoring events.
+Use for service startup, shutdown, removal, permission, and monitoring events.
 
 Applies to
 ----------
@@ -60,16 +60,16 @@ Procedure
 
    **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
+#. After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.
 
-   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
+   **Expected result:** For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.
 
-   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation.
 
 Verify the result
 -----------------
 
-Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
+Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.
 
 Evidence to collect
 -------------------

--- a/source/rsyslogwaspecific/event-id-reference/procedures.rst
+++ b/source/rsyslogwaspecific/event-id-reference/procedures.rst
@@ -15,6 +15,7 @@ expected results, failure branches, recovery verification, and evidence collecti
 - :ref:`Diagnose log rotation and retention <event-id-procedure-file-diagnose-log-rotation>` — Verify trigger, names, handles, destination access, and retention.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 - :ref:`Interpret a Windows or Winsock error code <event-id-procedure-windows-interpret-error-code>` — Translate a numeric code without losing its operation or subsystem context.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Resolve a destination and test its TCP port <event-id-procedure-network-resolve-host-and-test-tcp-port>` — Verify DNS, selected address, routing, and TCP establishment.
 - :ref:`Test an ODBC connection in the product context <event-id-procedure-database-test-odbc-connection>` — Verify ODBC provider, architecture, authentication, connectivity, and a minimal query.
 - :ref:`Test an OLE DB connection in the product context <event-id-procedure-database-test-oledb-connection>` — Verify OLE DB provider, architecture, authentication, connectivity, and a minimal query.

--- a/source/winsyslogspecific/event-id-reference/event-id-100.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-100.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product installation or explicit service-install operation registered the Windows service.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service installation was intended.
+#. If the registration was unexpected, identify the installation or administrative action that occurred at the same time.
+#. Verify the registered service name, executable path, start mode, and service account before starting it.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 100 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the intended service registration and that the service can enter the Running state.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-101.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-101.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service was removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A product uninstall or explicit service-remove operation deleted the Windows service registration.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when service removal was intended.
+#. If removal was unexpected, identify the uninstall or administrative action that occurred at the same time.
+#. Reinstall the service only after confirming that the product files and configuration should remain on this system.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 101 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after an intended removal, or is present and starts normally after an authorized reinstall.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-102.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-102.rst
@@ -16,7 +16,7 @@ WinSyslog Event ID 102: The service could not be removed
 Answer
 ------
 
-The Windows service remains registered.
+Windows rejected the request to delete the product service registration, so the service remains registered. This legacy event does not include the Windows error code.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service could not be removed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The {service_name} service could not be removed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The account performing removal lacks permission to delete the service.
+- The service or another process still holds a Service Control Manager handle and Windows has marked it for deletion.
+- The service name or registration state changed during removal.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Record the event timestamp and inspect neighboring Service Control Manager and installer events for the underlying Windows error.
+#. Confirm the current service registration and whether Windows already marked the service for deletion.
+#. Close management tools that hold service handles, use an authorized administrator account, and retry the intended uninstall once.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 102 does not recur and that windows service lifecycle processing continues.
+Confirm that the service registration is absent after the authorized removal and that Event ID 102 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-103.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-103.rst
@@ -16,7 +16,7 @@ WinSyslog Event ID 103: The service control handler could not be installed
 Answer
 ------
 
-Windows cannot deliver normal service control requests to the process.
+The service process could not register its control handler with Windows and terminates startup before normal service controls can be processed.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service control handler could not be installed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The control handler could not be installed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The executable was started outside the Service Control Manager instead of as the registered Windows service.
+- Windows rejected handler registration because the service process or registration state is invalid.
+- A Windows service-control failure occurred during very early startup.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Start the product through Windows Services or Start-Service, not by launching the service executable interactively.
+#. Check neighboring Service Control Manager events and the registered executable path.
+#. Repair the product installation if the service registration points to the wrong executable, then perform one controlled start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 103 does not recur and that windows service lifecycle processing continues.
+Confirm that Windows reports the service as Running and that normal stop and start controls work without Event ID 103.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-104.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-104.rst
@@ -16,7 +16,7 @@ WinSyslog Event ID 104: The service initialization process failed
 Answer
 ------
 
-The product service did not start.
+Product initialization returned a failure to the Windows service wrapper, so the service does not enter the Running state. An earlier product event normally identifies the specific initialization failure.
 
 Event details
 -------------
@@ -26,20 +26,21 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service initialization process failed. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The initialization process failed.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- License validation, configuration loading, or input-service startup failed earlier in the same startup attempt.
+- The service account cannot access a required file, registry key, network resource, provider, or certificate.
+- A required Windows resource or product component failed during initialization.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Find the first product error immediately before Event ID 104 in the same startup attempt; treat that earlier event as the primary cause.
+#. Record the service account, registered executable path, dependencies, and complete Service Control Manager events for the attempt.
+#. Correct only the specific earlier failure, then perform one controlled service start.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 104 does not recur and that windows service lifecycle processing continues.
+Confirm that the service reaches Running, at least one configured input starts, and Event ID 104 does not recur during that start.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-105.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-105.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was started. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was started.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows started the product service and product initialization completed successfully.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the start was intended.
+#. If starts are unexpected or frequent, correlate this event with preceding stop, crash, restart-recovery, update, or administrative events.
+#. Verify one configured input and destination instead of relying on service state alone.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 105 does not recur and that windows service lifecycle processing continues.
+Confirm that the service remains Running and processes one identifiable event through the intended destination.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-106.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-106.rst
@@ -16,7 +16,7 @@ WinSyslog Event ID 106: The service received an unsupported control request
 Answer
 ------
 
-The requested Windows service-control operation was not performed.
+Windows delivered a service-control code that this product service does not implement. The requested control is ignored while supported service operations continue. This legacy event does not identify the control code.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service received an unsupported control request. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service received an unsupported request.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- A management tool or script sent a control code that the product does not support.
+- A monitoring or service-management integration used the wrong control operation.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Use management-tool, script, and Service Control Manager logs from the event timestamp to identify the caller and control operation.
+#. Change the caller to use supported start, stop, or other documented service operations.
+#. Confirm that the service remains in its intended state after removing the unsupported request.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 106 does not recur and that windows service lifecycle processing continues.
+Run the corrected management operation and confirm the intended service state without Event ID 106.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-108.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-108.rst
@@ -26,20 +26,19 @@ Event details
 - **Component:** Windows service lifecycle
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The service was stopped. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The service was stopped.`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- Windows, an administrator, an installer, or product shutdown logic requested an orderly stop.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. No repair is required when the stop was intended.
+#. If the stop was unexpected, inspect preceding product and Service Control Manager events for the initiating condition.
+#. Distinguish this orderly stop from a process termination or crash before changing configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +50,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 108 does not recur and that windows service lifecycle processing continues.
+Confirm that an intended stop leaves the service Stopped, or that an authorized restart remains Running and processes one identifiable event.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-11005.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-11005.rst
@@ -16,7 +16,7 @@ WinSyslog Event ID 11005: Configured feature is not licensed
 Answer
 ------
 
-The module or option is not loaded at startup.
+The product skipped the named input service, action, or advanced feature because the signed license does not include its required feature entitlement.
 
 Event details
 -------------
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The configuration enables a module that is not included in the installed edition or license.
+- A configuration copied from another product or edition contains a feature that is unavailable here.
+- The installed signed license does not match the intended product, version, or feature set.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the module kind, module name, and required feature identifier from the complete event detail.
+#. Confirm the running product, version, edition, and displayed license status without copying the license payload.
+#. Either install an authorized license that includes the feature or disable the unsupported configured object, then reload the configuration.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11005 does not recur and that licensing processing continues.
+Confirm that the intended module loads after configuration reload and performs one positive test without Event ID 11005 recurring.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-11043.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-11043.rst
@@ -3,27 +3,27 @@
 .. _winsyslog-event-id-11043:
 
 .. meta::
-   :description: Meaning and troubleshooting for WinSyslog Event ID 11043: Licensing: connection attempt failed.
+   :description: Meaning and troubleshooting for WinSyslog Event ID 11043: A sender connection was refused by the permitted-senders limit.
    :event-id: 11043
    :event-product: WinSyslog
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-WinSyslog Event ID 11043: Licensing: connection attempt failed
-==============================================================
+WinSyslog Event ID 11043: A sender connection was refused by the permitted-senders limit
+========================================================================================
 
 Answer
 ------
 
-Licensing: connection attempt failed. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
 
 Event details
 -------------
 
 - **Event ID:** ``11043``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Connection refused. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- Permitted Senders is enabled and the configured number of sender entries is already in use.
+- The connecting sender is not one of the currently permitted senders.
+- The permitted-senders configuration no longer matches the intended sender inventory.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Record the configured permitted-senders limit and whether the rejected sender should be allowed; do not publish the sender address.
+#. Review the current permitted-senders entries and remove only entries that are confirmed obsolete.
+#. If the intended sender count exceeds the configured or licensed allowance, update the authorized configuration or license before retrying.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11043 does not recur and that licensing processing continues.
+Send one identifiable test from an authorized sender and confirm that it is accepted exactly once without Event ID 11043.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-11043.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-11043.rst
@@ -16,7 +16,7 @@ WinSyslog Event ID 11043: A sender connection was refused by the permitted-sende
 Answer
 ------
 
-The product refused the sender identified in the event because the configured permitted-senders limit had already been reached.
+The product refused the sender identified in the event because the permitted-senders configuration has no available entry, does not include that sender, or no longer matches the intended sender inventory.
 
 Event details
 -------------
@@ -45,7 +45,7 @@ Immediate checks
 Detailed procedures
 -------------------
 
-- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 

--- a/source/winsyslogspecific/event-id-reference/event-id-11044.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-11044.rst
@@ -3,27 +3,27 @@
 .. _winsyslog-event-id-11044:
 
 .. meta::
-   :description: Meaning and troubleshooting for WinSyslog Event ID 11044: Licensing: licensed client limit exceeded.
+   :description: Meaning and troubleshooting for WinSyslog Event ID 11044: A sender connection exceeded the licensed client limit.
    :event-id: 11044
    :event-product: WinSyslog
    :event-severity: Error
-   :event-component: Licensing
+   :event-component: Client connection licensing
    :event-reference: true
 
-WinSyslog Event ID 11044: Licensing: licensed client limit exceeded
-===================================================================
+WinSyslog Event ID 11044: A sender connection exceeded the licensed client limit
+================================================================================
 
 Answer
 ------
 
-Licensing: licensed client limit exceeded. The product recorded this while processing licensing; the appended event detail identifies the affected object, operation, or provider error.
+The product refused the sender identified in the event because accepting it would exceed the client-connection allowance of the installed edition or license.
 
 Event details
 -------------
 
 - **Event ID:** ``11044``
 - **Severity:** Error
-- **Component:** Licensing
+- **Component:** Client connection licensing
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** 26.07
 - **Message pattern:** :spelling:ignore:`Client license limit exceeded. Additional detail: {event_detail}`
@@ -31,15 +31,16 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- More distinct senders are connecting than the installed edition or license permits.
+- A changed sender address causes an existing device to be counted as an additional client.
+- The installed license is not the intended license for this product or system.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Confirm the running product, edition, displayed license status, and client allowance without copying license data.
+#. Compare the intended sender inventory with the currently accepted senders and identify address changes or unintended sources.
+#. Remove unintended senders or install an authorized license with sufficient client capacity, then retry one controlled sender test.
 
 Detailed procedures
 -------------------
@@ -51,7 +52,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11044 does not recur and that licensing processing continues.
+Send one identifiable test from the intended sender and confirm that it is accepted exactly once without Event ID 11044.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-11186.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-11186.rst
@@ -3,55 +3,55 @@
 .. _winsyslog-event-id-11186:
 
 .. meta::
-   :description: Meaning and troubleshooting for WinSyslog Event ID 11186: Service configuration: trial period expired.
+   :description: Meaning and troubleshooting for WinSyslog Event ID 11186: The trial expired and the service was disabled.
    :event-id: 11186
    :event-product: WinSyslog
    :event-severity: Error
-   :event-component: Service configuration
+   :event-component: Licensing
    :event-reference: true
 
-WinSyslog Event ID 11186: Service configuration: trial period expired
-=====================================================================
+WinSyslog Event ID 11186: The trial expired and the service was disabled
+========================================================================
 
 Answer
 ------
 
-Service configuration: trial period expired. The product recorded this while processing service configuration; the appended event detail identifies the affected object, operation, or provider error.
+The evaluation period ended without a valid license, and this product does not permit continued free operation. The product keeps the configuration but does not start its input services.
 
 Event details
 -------------
 
 - **Event ID:** ``11186``
 - **Severity:** Error
-- **Component:** Service configuration
+- **Component:** Licensing
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** 26.07
-- **Message pattern:** :spelling:ignore:`Servicemanager. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`ServiceManager. Trial expired. The service is disabled and the existing configuration remains intact. Additional detail: {event_detail}`
 
 Possible causes
 ---------------
 
-- The product service, dependency, service account, or required Windows resource is unavailable or incorrectly configured.
-- Windows returned the appended startup, shutdown, permission, timeout, or resource error.
+- The evaluation period expired and no valid product license is installed.
+- The installed license is invalid for the running product or version.
 
 Immediate checks
 ----------------
 
-#. Record the affected service or component, service account, state, dependencies, and complete runtime detail.
-#. Check recent Service Control Manager and neighboring product events for the first failure.
-#. Correct the specific dependency, account, permission, or resource condition and perform one controlled retry.
+#. Confirm the exact product, version, and displayed license state without copying license data.
+#. Install the authorized license for this product and version; do not edit signed license content.
+#. Start the service and verify that its configured inputs load and process one controlled test.
 
 Detailed procedures
 -------------------
 
-- :ref:`Validate configuration and reload it safely <event-id-procedure-config-validate-and-reload>` — Back up, inspect, correct, and test the exact invalid configuration object.
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>` — Confirm product, version, validity, edition, and required feature without exposing license data.
 - :ref:`Collect an Event ID and neighboring product events <event-id-procedure-evidence-collect-event-and-neighboring-events>` — Preserve the complete event and the product events immediately before and after it.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 11186 does not recur and that service configuration processing continues.
+Confirm that the Windows service remains running, at least one configured input starts, and Event ID 11186 does not recur.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-118.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-118.rst
@@ -3,20 +3,20 @@
 .. _winsyslog-event-id-118:
 
 .. meta::
-   :description: Meaning and troubleshooting for WinSyslog Event ID 118: Trial mode reminder.
+   :description: Meaning and troubleshooting for WinSyslog Event ID 118: Product license status reminder.
    :event-id: 118
    :event-product: WinSyslog
    :event-severity: Information
    :event-component: Licensing
    :event-reference: true
 
-WinSyslog Event ID 118: Trial mode reminder
-===========================================
+WinSyslog Event ID 118: Product license status reminder
+=======================================================
 
 Answer
 ------
 
-Trial limits and expiration apply to the running product.
+The service reports its current license mode at startup. The event detail states whether the product is in trial mode with remaining evaluation time or is running in a registered edition.
 
 Event details
 -------------
@@ -26,20 +26,20 @@ Event details
 - **Component:** Licensing
 - **Windows Event Log source:** ``AdisconWinSyslog``
 - **Available since:** Current supported versions; original introduction not recorded
-- **Message pattern:** :spelling:ignore:`The product is running in trial mode; the event detail contains the remaining trial information. Additional detail: {event_detail}`
+- **Message pattern:** :spelling:ignore:`The product reports its trial or registered license mode. Additional detail: {license_status_detail}`
 
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The service started in trial mode and reports the remaining evaluation period.
+- The service started with a valid license and reports the active registered edition.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Read the complete event detail to distinguish trial mode from registered mode.
+#. No repair is required when the reported mode and edition are expected.
+#. If the mode is unexpected, compare the running product and version with the displayed license status without copying license data.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 118 does not recur and that licensing processing continues.
+Confirm that the service remains Running and that the reported license mode matches the intended product and edition.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-125.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-125.rst
@@ -31,15 +31,15 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The WinSyslog trial expired and the installed version permits continued operation in Free Edition mode.
+- No registered WinSyslog license is active, so Free Edition limits apply.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. No repair is required when Free Edition mode is intended.
+#. Review the active Free Edition limits before relying on additional senders or licensed features.
+#. If registered operation is intended, install the authorized WinSyslog license and restart the service.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 125 does not recur and that licensing processing continues.
+Confirm that WinSyslog reports the intended Free Edition or registered mode and processes one event within that edition's limits.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-900.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-900.rst
@@ -31,15 +31,15 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The installed key is invalid, altered, or not issued for this WinSyslog product and version.
+- License material was copied incompletely or placed in the wrong product configuration.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Confirm the running WinSyslog version and displayed license status without copying or editing the key.
+#. Replace the rejected material with the authorized license issued for this product and version.
+#. Start WinSyslog once and verify the reported license mode.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 900 does not recur and that licensing processing continues.
+Confirm that WinSyslog reaches Running, reports the intended licensed mode, and does not emit Event ID 900 during startup.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/event-id-901.rst
+++ b/source/winsyslogspecific/event-id-reference/event-id-901.rst
@@ -31,15 +31,15 @@ Event details
 Possible causes
 ---------------
 
-- The configured object is missing, invalid, unsupported by this product, or unavailable at runtime.
-- Windows or a required provider returned the operation-specific error appended to the event.
+- The installed key is on the product's blocked-key list and cannot authorize startup.
+- License material intended for a different or superseded installation is still configured.
 
 Immediate checks
 ----------------
 
-#. Identify the exact service, rule, filter, action, or setting named by the complete event detail.
-#. Compare that object with the product reference and preserve the first related error in the same time window.
-#. Correct only the identified setting or dependency, then run one controlled test.
+#. Do not modify or repeatedly re-enter the blocked key.
+#. Confirm the exact product and version, then obtain and install authorized replacement license material.
+#. Start the service once and verify the reported license mode.
 
 Detailed procedures
 -------------------
@@ -51,7 +51,7 @@ Detailed procedures
 Verify the result
 -----------------
 
-Repeat or monitor the affected operation and confirm that Event ID 901 does not recur and that licensing processing continues.
+Confirm that the service reaches Running, reports the intended licensed mode, and does not emit Event ID 901 during startup.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/index.rst
+++ b/source/winsyslogspecific/event-id-reference/index.rst
@@ -73,7 +73,7 @@ Event ID index
      - Information
      - Windows service lifecycle
    * - :ref:`118 <winsyslog-event-id-118>`
-     - Trial mode reminder
+     - Product license status reminder
      - Information
      - Licensing
    * - :ref:`125 <winsyslog-event-id-125>`
@@ -261,13 +261,13 @@ Event ID index
      - Error
      - Write to File action
    * - :ref:`11043 <winsyslog-event-id-11043>`
-     - Licensing: connection attempt failed
+     - A sender connection was refused by the permitted-senders limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11044 <winsyslog-event-id-11044>`
-     - Licensing: licensed client limit exceeded
+     - A sender connection exceeded the licensed client limit
      - Error
-     - Licensing
+     - Client connection licensing
    * - :ref:`11045 <winsyslog-event-id-11045>`
      - File-based configuration: file-based configuration could not be loaded
      - Error
@@ -829,9 +829,9 @@ Event ID index
      - Error
      - Service configuration
    * - :ref:`11186 <winsyslog-event-id-11186>`
-     - Service configuration: trial period expired
+     - The trial expired and the service was disabled
      - Error
-     - Service configuration
+     - Licensing
    * - :ref:`11187 <winsyslog-event-id-11187>`
      - A configured input service type is not recognized
      - Error

--- a/source/winsyslogspecific/event-id-reference/procedure/config-validate-and-reload.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/config-validate-and-reload.rst
@@ -40,27 +40,27 @@ Configuration Client > the service, rule, or action named on the Event ID page.
 Procedure
 ---------
 
-#. Export the configuration and open the exact service, rule, filter, or action named in the event.
+#. Export the pre-change configuration, then open only the exact service, ruleset, filter, or action named in the event.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The event detail and Configuration Client identify the same object and a readable pre-change export exists.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not infer the object from its type alone; collect the complete event and configuration export first.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the backup metadata, then check required references, product availability, paths, addresses, ports, and credentials for that object only.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
 
-   **Expected result:** A readable pre-change backup exists and all required fields reference valid product objects.
+   **Expected result:** Every required reference resolves to an existing object and every selected feature is available in this product and edition.
 
-   **If it fails:** Restore the export if the edited configuration cannot load; do not copy objects from another product manual.
+   **If it fails:** Restore the export if the edited configuration cannot load; do not copy unsupported objects from another product or edition.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Save the smallest correction, reload the configuration using the Configuration Client's normal apply path, and run one identifiable test through the edited object.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Restore the pre-change export if loading fails, then collect the first new product event and bounded debug output without changing unrelated objects.
 
 Rollback
 --------
@@ -71,7 +71,7 @@ Rollback
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the corrected object loads, the intended destination records one identifiable test, and neighboring rules and services continue normally.
 
 Evidence to collect
 -------------------
@@ -107,7 +107,6 @@ Related Event IDs
 - :ref:`WinSyslog Event ID 11183 <winsyslog-event-id-11183>`
 - :ref:`WinSyslog Event ID 11184 <winsyslog-event-id-11184>`
 - :ref:`WinSyslog Event ID 11185 <winsyslog-event-id-11185>`
-- :ref:`WinSyslog Event ID 11186 <winsyslog-event-id-11186>`
 - :ref:`WinSyslog Event ID 11187 <winsyslog-event-id-11187>`
 - :ref:`WinSyslog Event ID 11189 <winsyslog-event-id-11189>`
 - :ref:`WinSyslog Event ID 11191 <winsyslog-event-id-11191>`

--- a/source/winsyslogspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -42,27 +42,29 @@ Procedure
 
 #. Record the Event Log source, Event ID, level, timestamp, and complete General and Details data.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The record includes the provider, Event ID, timestamp with time zone, message text, and all dynamic detail.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the host clock state, then collect only the product events in a bounded window around the event.
 
    .. code-block:: powershell
 
+      Get-Date -Format o
+      w32tm /query /status
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The output contains the first product failure and later state or recovery events.
+   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Increase the bounded time window and verify the Event Log source shown on the Event ID page.
+   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
    **Expected result:** The intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Collect the first new product event and bounded debug output from that exact test; do not change unrelated settings.
 
 Verify the result
 -----------------
@@ -72,8 +74,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
+- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
 
 Related Event IDs
 -----------------

--- a/source/winsyslogspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/evidence-collect-event-and-neighboring-events.rst
@@ -46,19 +46,28 @@ Procedure
 
    **If it fails:** Export the original event as an EVTX file before copying text or changing filters.
 
-#. Record the host clock state, then collect only the product events in a bounded window around the event.
+#. For every host involved in the affected flow, including the affected product host, sender, and destination, use an elevated PowerShell session when available to record that host's clock state.
 
    .. code-block:: powershell
 
       Get-Date -Format o
       w32tm /query /status
+
+   **Expected result:** Each involved host has a recorded local timestamp and either clock-status output or the recorded query error. If elevation is unavailable or the time service cannot be queried, treat that host's clock synchronization as unverified.
+
+   **If it fails:** If the Windows Time status command returns access denied or the time service is unavailable, do not change time settings or services. Record Get-Date output and the query error, request clock status from an authorized administrator if correlation is required, and continue with the affected-host event capture.
+
+#. On the affected product host, collect only the product events in a bounded window around the event.
+
+   .. code-block:: powershell
+
       $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
       $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
       Get-WinEvent -FilterHashtable @{LogName='Application';StartTime=$start;EndTime=$end} | Where-Object ProviderName -eq '<EVENT_SOURCE>' | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The clock output is recorded and the event sequence contains the first failure plus any later state or recovery event.
+   **Expected result:** The event sequence contains the first failure plus any later state or recovery event.
 
-   **If it fails:** Verify the provider shown on the Event ID page. Expand the window only enough to include the first related event.
+   **If it fails:** Verify the provider shown on the Event ID page and expand the window only enough to include the first related event.
 
 #. After diagnosis, perform one uniquely identifiable product test through the same input, rule, and action, and record its sender and destination timestamps.
 
@@ -75,8 +84,8 @@ Evidence to collect
 -------------------
 
 - The original EVTX record plus the complete rendered event and neighboring product events with timestamps.
-- Clock-status output from every involved host and the sender and destination timestamps for the identifiable test.
-- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, hostnames, and environment-specific object names removed.
+- Clock-status output or the recorded query error from every involved host, plus the sender and destination timestamps for the identifiable test.
+- The relevant configuration export and bounded debug log from the same interval, with credentials, license data, private keys, addresses, and other secrets removed. Preserve hostnames and configuration object names needed to identify the affected systems and settings.
 
 Related Event IDs
 -----------------

--- a/source/winsyslogspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/evidence-export-configuration-and-debug-log.rst
@@ -40,28 +40,30 @@ Configuration Client > Computer > Export Settings to Registry File; then General
 Procedure
 ---------
 
-#. Export settings as a text registry file, then enable the minimum debug level that reproduces the problem.
+#. Before changing settings, use Computer > Export Settings to Registry File and save a pre-change text export in a protected working directory.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** A readable pre-change export exists and its modification time precedes the troubleshooting change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not continue with a state-changing repair until a readable pre-change export exists.
 
-#. Run the native Windows checks below from the affected product host.
+#. Record the start time, enable only the debug output required to reproduce once, then record the end time and disable debugging immediately.
 
    .. code-block:: powershell
 
+      $captureStart=Get-Date; $captureStart.ToString('o')
       Get-Item -LiteralPath '<CONFIG_EXPORT>' | Format-List FullName,Length,LastWriteTime
       Get-Item -LiteralPath '<DEBUG_LOG>' | Format-List FullName,Length,LastWriteTime
+      $captureEnd=Get-Date; $captureEnd.ToString('o')
 
-   **Expected result:** Both files exist, are readable, and cover the recorded reproduction interval.
+   **Expected result:** The export and debug log are readable, the log covers the recorded interval, and debug output is disabled after the reproduction.
 
-   **If it fails:** Verify the service account can write the debug directory and restart only if the setting requires it.
+   **If it fails:** Verify the configured debug path and service-account write access. Do not leave debugging enabled while investigating a missing log.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Preserve only the bounded interval around one uniquely identifiable test, then create redacted copies for review.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The test and its outcome can be correlated across the redacted export, Event Log, and bounded debug interval.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Repeat only after correcting the capture window; do not collect an unbounded debug log.
 
 Verify the result
 -----------------
@@ -71,8 +73,9 @@ Repeat the affected operation, confirm its positive output, and verify that queu
 Evidence to collect
 -------------------
 
-- The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- The capture start and end timestamps, complete Event Log entry, and neighboring product events.
+- The pre-change configuration export and bounded debug log from the same interval.
+- Redacted review copies with credentials, license data, private keys, addresses, hostnames, paths, database identifiers, certificate identities, and environment-specific service, ruleset, and action names removed.
 
 Related Event IDs
 -----------------

--- a/source/winsyslogspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/license-repair-permitted-senders-configuration.rst
@@ -1,0 +1,88 @@
+:orphan:
+
+.. _event-id-procedure-license-repair-permitted-senders-configuration:
+
+.. meta::
+   :description: Authorize an intended sender without weakening the sender restriction.
+   :procedure-id: license.repair-permitted-senders-configuration
+   :procedure-reference: true
+
+Repair the permitted-senders configuration
+==========================================
+
+When to use this procedure
+--------------------------
+
+Use for Event ID 11043 when a sender should be permitted but is absent from, or outside the active range of, the permitted-senders configuration.
+
+Applies to
+----------
+
+This procedure applies to WinSyslog.
+
+Prerequisites
+-------------
+
+- Use an account that can read and update the affected product configuration.
+- Replace angle-bracket placeholders with values from the affected system.
+
+Safety
+------
+
+- Do not disable permitted-senders protection solely to accept a sender.
+- Do not publish sender addresses or a full configuration export.
+
+Configuration path
+------------------
+
+Configuration Client > General > permitted-senders settings.
+
+Procedure
+---------
+
+#. Record whether permitted senders is enabled, the configured sender count, and the position of each intended sender without recording sender addresses.
+
+   **Expected result:** The intended sender and the active permitted-sender positions are known.
+
+   **If it fails:** Collect a redacted configuration summary and the complete Event ID 11043 detail before changing the sender list.
+
+#. Compare the intended sender inventory with the configured count and active entry order.
+
+   **Expected result:** Each required sender is present within the active permitted-sender range.
+
+   **If it fails:** Remove or replace an entry only when it is confirmed obsolete; do not disable permitted-senders protection.
+
+#. If the rejected sender is intended and capacity is available, add it to, or move it into, the active permitted-sender range. If the required inventory exceeds the configured or licensed allowance, obtain the authorized capacity before retrying.
+
+   **Expected result:** The intended sender is authorized without admitting unapproved senders.
+
+   **If it fails:** Do not broaden network access as a workaround. Record the non-secret configured count and license allowance, then follow the approved capacity process.
+
+#. Apply the configuration as required by the product, then send one uniquely identifiable test from the intended sender.
+
+   **Expected result:** The product accepts the test exactly once and Event ID 11043 does not recur.
+
+   **If it fails:** Restore the previous sender order if the change was unintended, then collect the new Event ID 11043 detail and a redacted configuration summary.
+
+Verify the result
+-----------------
+
+Confirm that every required sender remains authorized, unapproved senders remain refused, and the intended sender completes one test without Event ID 11043.
+
+Evidence to collect
+-------------------
+
+- The complete Event ID 11043 entry and neighboring product events with timestamps.
+- A redacted list of sender positions, configured count, and intended-sender status; do not collect sender addresses.
+- The product version and non-secret license allowance when the intended inventory exceeds the configured count.
+
+Related Event IDs
+-----------------
+
+- :ref:`WinSyslog Event ID 11043 <winsyslog-event-id-11043>`
+
+
+Related procedures
+------------------
+
+- :ref:`Verify product license and feature entitlement state <event-id-procedure-license-verify-license-state>`

--- a/source/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -42,36 +42,37 @@ Procedure
 
 #. Record product version, displayed license status, edition, and feature named in the event without copying the license payload.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The running product, version, edition, license mode, and required feature or client allowance are known without exposing license material.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Run the native Windows checks below from the affected product host.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The signed license targets the running product/version and includes the configured feature.
+   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
 
-   **If it fails:** Install the authorized license or disable unsupported configuration; never edit signed data.
+   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
 
 Evidence to collect
 -------------------
 
 - The complete Event Log entry and neighboring product events with timestamps.
-- The command output, relevant configuration export, and bounded debug log from the same interval.
+- Product name, executable version, displayed edition or license mode, and the non-secret feature or client allowance involved.
+- A redacted configuration export showing only the affected object; never collect license files, keys, signed payloads, activation data, or customer identifiers.
 
 Related Event IDs
 -----------------
@@ -83,3 +84,4 @@ Related Event IDs
 - :ref:`WinSyslog Event ID 11005 <winsyslog-event-id-11005>`
 - :ref:`WinSyslog Event ID 11043 <winsyslog-event-id-11043>`
 - :ref:`WinSyslog Event ID 11044 <winsyslog-event-id-11044>`
+- :ref:`WinSyslog Event ID 11186 <winsyslog-event-id-11186>`

--- a/source/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/license-verify-license-state.rst
@@ -13,7 +13,7 @@ Verify product license and feature entitlement state
 When to use this procedure
 --------------------------
 
-Use for trial, license validation, edition, and feature-denied events.
+Use for trial or registered-status, license-validation, edition, and feature-denied events.
 
 Applies to
 ----------
@@ -46,26 +46,26 @@ Procedure
 
    **If it fails:** Do not copy the license file or key; record only the product UI's status and non-secret version information.
 
-#. Verify the running executable's product and version, then compare the displayed entitlement with the module or client allowance named by the event.
+#. Verify the running executable's product and version, then compare the displayed entitlement with the state identified by the event. For a denial event, also compare the named module, feature, or client allowance.
 
    .. code-block:: powershell
 
       Get-Item -LiteralPath '<PRODUCT_EXECUTABLE>' | Select-Object -ExpandProperty VersionInfo | Format-List ProductName,ProductVersion,FileVersion
 
-   **Expected result:** The authorized license targets the running product and version and includes the required feature or sufficient client capacity.
+   **Expected result:** For a denial event, the authorized license targets the running product and version and includes the required feature or sufficient client capacity. For a status reminder, the displayed state matches the intended product and edition.
 
-   **If it fails:** Install authorized replacement license material or disable the unsupported configuration; never edit signed data.
+   **If it fails:** For a denial event, install authorized replacement license material or disable the unsupported configuration. For an unexpected status reminder, record the non-secret product version and displayed state before seeking license assistance; never edit signed data.
 
-#. Restart or reload only as required by the license installation, then test the previously denied module or intended sender once.
+#. For a denial event after changing license material, restart or reload only as required, then test the previously denied module or intended sender once. For a status reminder, do not change licensing; confirm the displayed state and that the service continues normally.
 
-   **Expected result:** The service remains Running and the intended module or sender processes the test exactly once without a license-denial event.
+   **Expected result:** For a denial event, the service remains Running and the intended module or sender processes the test exactly once without a license-denial event. For a status reminder, the displayed license state is expected and the service remains Running.
 
    **If it fails:** Record the new license-status and denial events without sharing license data; do not repeatedly reinstall or alter the license.
 
 Verify the result
 -----------------
 
-Confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material.
+For a denial event, confirm the intended license mode in the product UI and prove the previously denied module or sender works once without exposing license material. For a status reminder, confirm that the displayed license mode and service state are expected.
 
 Evidence to collect
 -------------------
@@ -82,6 +82,5 @@ Related Event IDs
 - :ref:`WinSyslog Event ID 900 <winsyslog-event-id-900>`
 - :ref:`WinSyslog Event ID 901 <winsyslog-event-id-901>`
 - :ref:`WinSyslog Event ID 11005 <winsyslog-event-id-11005>`
-- :ref:`WinSyslog Event ID 11043 <winsyslog-event-id-11043>`
 - :ref:`WinSyslog Event ID 11044 <winsyslog-event-id-11044>`
 - :ref:`WinSyslog Event ID 11186 <winsyslog-event-id-11186>`

--- a/source/winsyslogspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -42,31 +42,34 @@ Procedure
 
 #. Identify the internal Windows service name and intended service account.
 
-   **Expected result:** The affected object and its effective settings are identified.
+   **Expected result:** The internal service name and intended account are known before any start, stop, or account change.
 
-   **If it fails:** Return to the complete Event Log detail and configuration export before changing settings.
+   **If it fails:** Use the service Properties dialog or the command output below; do not guess the internal name.
 
-#. Run the native Windows checks below from the affected product host.
+#. Capture current service configuration, state, required dependencies, and bounded Service Control Manager events.
 
    .. code-block:: powershell
 
-      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,State,StartMode,StartName,ExitCode
+      Get-CimInstance Win32_Service -Filter "Name='<SERVICE_NAME>'" | Format-List Name,DisplayName,State,StartMode,StartName,PathName,ExitCode
       Get-Service -Name '<SERVICE_NAME>' -RequiredServices | Format-Table Name,Status,StartType
+      $start=(Get-Date '<EVENT_TIME>').AddMinutes(-5)
+      $end=(Get-Date '<EVENT_TIME>').AddMinutes(5)
+      Get-WinEvent -FilterHashtable @{LogName='System';ProviderName='Service Control Manager';StartTime=$start;EndTime=$end} | Format-List TimeCreated,Id,LevelDisplayName,Message
 
-   **Expected result:** The service and required dependencies are in the intended state under the intended account.
+   **Expected result:** The executable path, start mode, service account, dependencies, and first Windows service error agree with the intended installation.
 
-   **If it fails:** Use recent Service Control Manager events to correct a dependency, logon, timeout, or termination failure.
+   **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. Perform one uniquely identifiable product test through the same service, rule, or action.
+#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
 
-   **Expected result:** The intended destination records the test exactly once.
+   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
 
-   **If it fails:** Collect the first new product event and bounded debug output; do not change unrelated settings.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
 
 Verify the result
 -----------------
 
-Repeat the affected operation, confirm its positive output, and verify that queues, collection positions, or remote delivery continue normally.
+Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/procedure/service-verify-state-and-account.rst
+++ b/source/winsyslogspecific/event-id-reference/procedure/service-verify-state-and-account.rst
@@ -13,7 +13,7 @@ Verify service state, dependencies, and service account
 When to use this procedure
 --------------------------
 
-Use for service startup, shutdown, permission, and monitoring events.
+Use for service startup, shutdown, removal, permission, and monitoring events.
 
 Applies to
 ----------
@@ -60,16 +60,16 @@ Procedure
 
    **If it fails:** Use the first Service Control Manager error to distinguish a dependency, account-logon, path, timeout, or process-termination failure.
 
-#. After correcting the specific startup condition, start the service once and perform one identifiable product test.
+#. After correcting the condition, repeat the requested lifecycle operation once. For startup events, start the service and perform one identifiable product test; for removal events, retry the intended removal and do not restart the service.
 
-   **Expected result:** The service remains Running, at least one configured input is active, and the intended destination records the test exactly once.
+   **Expected result:** For startup events, the service remains Running, at least one configured input is active, and the intended destination records the test exactly once. For removal events, the service registration is absent after the authorized removal. For other lifecycle events, only the requested state changes.
 
-   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from that start attempt.
+   **If it fails:** Stop retrying and collect the first new product and Service Control Manager errors from the attempted operation.
 
 Verify the result
 -----------------
 
-Confirm that the service remains Running and that one configured input processes an identifiable event through its intended destination.
+Confirm the requested lifecycle state: Running after startup, Stopped after shutdown, and registration absent after removal. Perform an identifiable product test only when the service is expected to run.
 
 Evidence to collect
 -------------------

--- a/source/winsyslogspecific/event-id-reference/procedures.rst
+++ b/source/winsyslogspecific/event-id-reference/procedures.rst
@@ -15,6 +15,7 @@ expected results, failure branches, recovery verification, and evidence collecti
 - :ref:`Diagnose log rotation and retention <event-id-procedure-file-diagnose-log-rotation>` — Verify trigger, names, handles, destination access, and retention.
 - :ref:`Export configuration and collect a bounded debug log <event-id-procedure-evidence-export-configuration-and-debug-log>` — Create a text configuration export and time-bounded debug capture, then disable debugging.
 - :ref:`Interpret a Windows or Winsock error code <event-id-procedure-windows-interpret-error-code>` — Translate a numeric code without losing its operation or subsystem context.
+- :ref:`Repair the permitted-senders configuration <event-id-procedure-license-repair-permitted-senders-configuration>` — Authorize an intended sender without weakening the sender restriction.
 - :ref:`Resolve a destination and test its TCP port <event-id-procedure-network-resolve-host-and-test-tcp-port>` — Verify DNS, selected address, routing, and TCP establishment.
 - :ref:`Test an ODBC connection in the product context <event-id-procedure-database-test-odbc-connection>` — Verify ODBC provider, architecture, authentication, connectivity, and a minimal query.
 - :ref:`Test an OLE DB connection in the product context <event-id-procedure-database-test-oledb-connection>` — Verify OLE DB provider, architecture, authentication, connectivity, and a minimal query.


### PR DESCRIPTION
## Summary

- regenerate the public Event ID reference from Himalaya PR #471
- improve lifecycle, configuration, evidence-collection, and licensing procedures with bounded collection, backup, rollback, decision points, and positive recovery checks
- clarify the shared license-status reminder and product/license-limit diagnostics
- retain product-specific generated pages and public JSON without exposing internal diagnostic keys

## Dependency and merge order

This PR intentionally remains draft until its upstream catalog dependency is merged.

1. Merge Adiscon/himalaya#471 first.
2. Regenerate this PR from the exact merged Himalaya commit and rerun all checks.
3. Merge this documentation PR second.

The import is pinned to exact Himalaya merge commit `b1d024ddc253bc74690a0d2af326e9015b3772e2`. It includes reviewed procedure mappings for all 240 imported diagnostics; six diagnostics introduced in 26.08 remain correctly hidden from the current 26.07 manuals by version gating.

## Validation

- diagnostic reference generator check: 1,017 files
- public Event ID/procedure JSON validation
- strict Sphinx HTML builds for all six manuals
- doc8 and rstcheck
- spelling for all six manuals
- rendered JSON-LD checks for Event ID and HowTo pages
- deterministic and semantic privacy review of the public diff

The native clock command was exercised on Windows. `w32tm /query /status` correctly reported an access-denied result in the non-elevated validation session; the procedure records this command as evidence collection rather than assuming success.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repinned to `Himalaya` commit 6303266 and regenerated Event ID pages and public JSON. Improves lifecycle/licensing guidance, widens 11043 for permitted‑sender limits with a targeted repair procedure, keeps Message Ringbuffer version‑gated, and makes evidence capture elevation‑aware.

- **Refactors**
  - Catalog: imported Message Ringbuffer and mapped to config/evidence procedures; hidden by the 26.08 gate; validated generator, public JSON, and strict builds.
  - Lifecycle: standardized service‑name message patterns and clarified answers for 100–106, 108 across all products.
  - Licensing: 118 retitled to “Product license status reminder”; 11043 broadened to capacity/unlisted/stale senders and reclassified under Client connection licensing; 11044 reframed; 11186 retitled and aligned for WinSyslog Freeware Mode; updated Free Edition (125) and invalid/blocked key pages (900/901).
  - Procedures/guidance: added “Repair permitted‑senders configuration”; require pre‑change exports and single‑run, bounded debug; request elevated `w32tm`, record unverified clock correlation, check clocks on all involved hosts; anti‑patterns updated to branch by originating event and redact secrets while keeping needed identifiers.

<sup>Written for commit 035323ab9e50ee10adee1da4526cc7baffdfea09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-client-doc/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

