### PR TITLE
Document direct foreground file configuration

### DIFF
--- a/source/eventreporterspecific/commandlineswitches.rst
+++ b/source/eventreporterspecific/commandlineswitches.rst
@@ -23,6 +23,29 @@ stop working.
 
 The ``-v`` switch gives you information about the version of the service.
 
+Direct foreground configuration
+-------------------------------
+
+This capability is available starting with **26.08**.
+
+Foreground runs can use an ephemeral configuration without installing a
+service or creating a service ``Parameters`` key:
+
+- ``-r -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode file -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode registry [-regpath <path>]``
+
+Direct options take precedence for that foreground process only. File mode
+requires ``-fileconfig``; ``-datadir`` cannot be used alone or with explicit
+registry mode, and ``-regpath`` is available only with explicit registry mode.
+The existing ``-i`` installation configuration remains persistent and
+unchanged.
+
+The first direct foreground run registers the canonical Windows Event Log
+provider using the executable message file. This does not create a service.
+Provider creation or an update can require one elevated first run; the command
+reports that requirement before startup.
+
 **Custom service name examples:**
 
 - ``evntslog.exe -i CustomServiceName``

--- a/source/rsyslogwaspecific/commandlineswitches.rst
+++ b/source/rsyslogwaspecific/commandlineswitches.rst
@@ -24,6 +24,29 @@ stop working.
 
 The ``-v`` switch gives you information about the version of the service.
 
+Direct foreground configuration
+-------------------------------
+
+This capability is available starting with **26.08**.
+
+Foreground runs can use an ephemeral configuration without installing a
+service or creating a service ``Parameters`` key:
+
+- ``-r -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode file -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode registry [-regpath <path>]``
+
+Direct options take precedence for that foreground process only. File mode
+requires ``-fileconfig``; ``-datadir`` cannot be used alone or with explicit
+registry mode, and ``-regpath`` is available only with explicit registry mode.
+The existing ``-i`` installation configuration remains persistent and
+unchanged.
+
+The first direct foreground run registers the canonical Windows Event Log
+provider using the executable message file. This does not create a service.
+Provider creation or an update can require one elevated first run; the command
+reports that requirement before startup.
+
 **Custom service name examples:**
 
 - ``rsyslogd.exe -i CustomServiceName``

--- a/source/shared/references/commandlineswitches.rst
+++ b/source/shared/references/commandlineswitches.rst
@@ -32,6 +32,30 @@ stop working.
 
 The ``-v`` switch gives you information about the version of the service.
 
+Direct foreground configuration
+-------------------------------
+
+This capability is available starting with **26.08**.
+
+Foreground runs can use an ephemeral configuration without installing a
+service or creating a service ``Parameters`` key:
+
+- ``-r -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode file -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode registry [-regpath <path>]``
+
+Direct options take precedence over service configuration only for that
+foreground process. ``-fileconfig`` implies file mode; file mode requires it,
+and ``-datadir`` cannot be used by itself. Do not combine file options with
+explicit registry mode. ``-regpath`` is available only with explicit registry
+mode. The existing ``-i`` installation configuration remains persistent and
+unchanged.
+
+The first direct foreground run registers the product's canonical Windows
+Event Log provider using the executable message file. This does not create a
+service. Provider creation or an update can require one elevated first run;
+the command reports that requirement before startup.
+
 **Custom service name examples:**
 
 - ``mwagent.exe -i CustomServiceName``

--- a/source/winsyslogspecific/commandlineswitches.rst
+++ b/source/winsyslogspecific/commandlineswitches.rst
@@ -23,6 +23,29 @@ stop working.
 
 The ``-v`` switch gives you information about the version of the service.
 
+Direct foreground configuration
+-------------------------------
+
+This capability is available starting with **26.08**.
+
+Foreground runs can use an ephemeral configuration without installing a
+service or creating a service ``Parameters`` key:
+
+- ``-r -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode file -fileconfig <path> [-datadir <path>]``
+- ``-r -accessmode registry [-regpath <path>]``
+
+Direct options take precedence for that foreground process only. File mode
+requires ``-fileconfig``; ``-datadir`` cannot be used alone or with explicit
+registry mode, and ``-regpath`` is available only with explicit registry mode.
+The existing ``-i`` installation configuration remains persistent and
+unchanged.
+
+The first direct foreground run registers the canonical Windows Event Log
+provider using the executable message file. This does not create a service.
+Provider creation or an update can require one elevated first run; the command
+reports that requirement before startup.
+
 **Custom service name examples:**
 
 - ``WINSyslog.exe -i CustomServiceName``


### PR DESCRIPTION
Document direct -r file and registry configuration for MWAgent, WinSyslog, EventReporter, and rsyslog Windows Agent. Cover precedence over service Parameters, invalid combinations, persistent -i behavior, and the one-time elevation requirement for canonical Event Log provider registration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a “Direct foreground configuration” section to command‑line docs for MWAgent, WinSyslog, EventReporter, and rsyslog Windows Agent (available starting with 26.08). It explains running with `-r` without installing a service, precedence for that foreground process only, `-fileconfig` required for file mode, `-datadir` not alone or with explicit registry mode, `-regpath` only with explicit registry mode, do not mix file options with registry mode, `-i` remains persistent, and the first direct run registers the canonical Windows Event Log provider and may require one elevated run.

<sup>Written for commit 88ca20eeacfe830a18d00a789bd16734ca136edf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-client-doc/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

