### PR TITLE
fix: keep :spelling:ignore: roles available when spelling extension i…

### DIFF
--- a/conf_common.py
+++ b/conf_common.py
@@ -49,15 +49,23 @@ def get_shared_templates_path() -> str:
 
 
 def enable_spelling_extension(extensions: List[str]) -> List[str]:
-    """Add spelling extension only when the package and Enchant C library are available."""
-    if "sphinxcontrib.spelling" in extensions:
-        return extensions
+    """Add spelling extension when available; always ensure spelling roles exist.
 
-    try:
-        import sphinxcontrib.spelling  # noqa: F401
-        extensions.append("sphinxcontrib.spelling")
-    except Exception:  # pragma: no cover - e.g. Enchant C library not installed
-        pass
+    ``:spelling:ignore:`` / ``:spelling:word:`` are used in event-id pages. If
+    ``sphinxcontrib.spelling`` cannot be imported (missing package or Enchant),
+    those roles are unknown and strict builds (``-W``) fail — including CHM.
+    Always append ``spelling_role_fallback`` last so a no-op domain is registered
+    when the real spelling extension is absent.
+    """
+    if "sphinxcontrib.spelling" not in extensions:
+        try:
+            import sphinxcontrib.spelling  # noqa: F401
+            extensions.append("sphinxcontrib.spelling")
+        except Exception:  # pragma: no cover - e.g. Enchant C library not installed
+            pass
+
+    if "spelling_role_fallback" not in extensions:
+        extensions.append("spelling_role_fallback")
 
     return extensions
 

--- a/spelling_role_fallback.py
+++ b/spelling_role_fallback.py
@@ -1,0 +1,67 @@
+"""Fallback Sphinx extension for ``:spelling:ignore:`` / ``:spelling:word:``.
+
+Used when ``sphinxcontrib.spelling`` is unavailable (missing package or Enchant).
+Keeps HTML/HTMLHelp builds working under ``-W`` when sources use those roles.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+from docutils import nodes
+from docutils.parsers.rst.states import Inliner
+from sphinx.application import Sphinx
+from sphinx.domains import Domain
+
+
+def _passthrough_role(
+    typ: str,
+    rawtext: str,
+    text: str,
+    lineno: int,
+    inliner: Inliner,
+    options: Dict[str, Any] | None = None,
+    content: List[str] | None = None,
+) -> Tuple[List[nodes.Node], List[nodes.system_message]]:
+    """Render the role content as plain text (no spellcheck metadata)."""
+    return [nodes.inline(rawtext, text)], []
+
+
+class SpellingRoleFallbackDomain(Domain):
+    """Minimal stand-in for sphinxcontrib.spelling's domain roles."""
+
+    name = "spelling"
+    label = "Spelling (fallback)"
+    roles = {
+        "ignore": _passthrough_role,
+        "word": _passthrough_role,
+    }
+
+    def get_objects(self):
+        return []
+
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        return None
+
+    def resolve_any_xref(self, env, fromdocname, builder, target, node, contnode):
+        return []
+
+    def merge_domaindata(self, docnames, otherdata):
+        return
+
+
+def setup(app: Sphinx) -> Dict[str, Any]:
+    # If the real spelling extension already registered the domain, do nothing.
+    if "spelling" in app.registry.domains:
+        return {
+            "version": "1.0",
+            "parallel_read_safe": True,
+            "parallel_write_safe": True,
+        }
+
+    app.add_domain(SpellingRoleFallbackDomain)
+    return {
+        "version": "1.0",
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }


### PR DESCRIPTION
…s missing

Strict Sphinx builds (-W), including HTMLHelp/CHM, failed with hundreds of "Unknown interpreted text role 'spelling:ignore'" errors on event-id pages whenever sphinxcontrib.spelling was not loaded (missing package or Enchant). enable_spelling_extension() previously skipped the extension silently, so the roles never registered and CHM rebuilds aborted.

Add spelling_role_fallback.py with a no-op spelling domain that provides :spelling:ignore: and :spelling:word: as plain text. Always append that fallback after optionally enabling sphinxcontrib.spelling, and skip domain registration when the real spelling extension already owns the domain.

This unblocks make htmlhelp-<product> / make all-htmlhelp under -W when the spelling toolchain is incomplete, while leaving normal spelling builds unchanged when Enchant is available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `:spelling:ignore:` and `:spelling:word:` still work when `sphinxcontrib.spelling` isn’t installed, preventing strict (`-W`) HTMLHelp/CHM builds from failing.

- **Bug Fixes**
  - Added `spelling_role_fallback` Sphinx extension that provides a no-op `spelling` domain with `ignore` and `word` roles rendered as plain text.
  - Updated `enable_spelling_extension()` to always append the fallback after attempting to enable `sphinxcontrib.spelling`, and to skip fallback registration if the real domain is present.

<sup>Written for commit 8ec7f382542a11e2909a43d653b23c1f54dc60e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-client-doc/pull/108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

