### PR TITLE
Add customer-facing SNMP trap source erratum

### DIFF
--- a/source/mwagentspecific/references.rst
+++ b/source/mwagentspecific/references.rst
@@ -32,6 +32,16 @@ Technical lookup material
 
 .. include:: ../_generated/event-ids/mwagent/navigation.inc
 
+.. only:: winsyslog or winsyslog_j or mwagent
+
+   Known issues and errata
+   -----------------------
+
+   .. toctree::
+      :maxdepth: 1
+
+      ../shared/errata/index
+
 External reference
 ------------------
 

--- a/source/shared/errata/err-2026-001-snmp-trap-source-address.rst
+++ b/source/shared/errata/err-2026-001-snmp-trap-source-address.rst
@@ -1,0 +1,89 @@
+:orphan:
+
+.. _err-2026-001-snmp-trap-source-address:
+
+.. only:: winsyslog or winsyslog_j or mwagent
+
+   ERR-2026-001: Incorrect source address for received SNMP traps
+   ================================================================
+
+   **Status:** Correction scheduled
+
+   **First published:** August 6, 2026
+
+   Description
+   -----------
+
+   The SNMP Trap Receiver can record the name or address of the local system as
+   the event source instead of the address of the device that sent the trap.
+   The incorrect value can appear both in the event source property and in the
+   formatted message text.
+
+   The trap is still received and processed. The problem is limited to sender
+   attribution for events received by the SNMP Trap Receiver. Source detection
+   for the Syslog service and other input services is not affected.
+
+   Affected products
+   -----------------
+
+   - **WinSyslog:** service versions ``18.3.0.657``, ``18.4.0.661``,
+     ``26.07.0.768``, and ``26.08.0.773``
+   - **MonitorWare** `Agent <https://www.mwagent.com/>`_: service versions
+     ``15.3.0.572``, ``15.4.0.576``, ``26.07.0.683``, and ``26.08.0.688``
+
+   Impact
+   ------
+
+   Rules, files, database records, alerts, or forwarded messages that rely on
+   the event source can identify the receiving Windows system instead of the
+   device that sent the SNMP trap. This can affect device-specific filtering,
+   correlation, and incident analysis.
+
+   How to determine whether you are affected
+   -----------------------------------------
+
+   You are affected when all of the following conditions apply:
+
+   - You use an affected service version listed above.
+   - You receive events through the SNMP Trap Receiver.
+   - The recorded source is the local product host instead of the sending
+     device.
+
+   Send a test trap from a device with a known address and compare that address
+   with the event source property and any ``source=`` value in the formatted
+   message.
+
+   Workarounds
+   -----------
+
+   There is no configuration change that restores the correct sender address
+   in the affected versions.
+
+   If correct source attribution is operationally critical, contact Adiscon
+   Support to review a controlled rollback. The last known unaffected service
+   versions are WinSyslog ``18.2.0.656`` and MonitorWare
+   `Agent <https://www.mwagent.com/>`_ ``15.2.0.571``. Before a rollback, back
+   up the configuration and verify compatibility because a configuration saved
+   by a later release can contain settings that an earlier release does not
+   support.
+
+   When a rollback is not suitable, use an independent network capture or the
+   sending device's own records to confirm the sender. Do not rely on the
+   affected source field alone for device-specific processing or incident
+   decisions.
+
+   Resolution
+   ----------
+
+   A correction is scheduled for the ``26.09`` release of WinSyslog and
+   MonitorWare `Agent <https://www.mwagent.com/>`_. This notice will be updated
+   with the exact corrected service builds when those releases are available.
+
+   After updating, send a test trap from a device with a known address and
+   confirm that the event source property and formatted message identify that
+   device.
+
+   Revision history
+   ----------------
+
+   - **August 6, 2026:** Initial publication.

--- a/source/shared/errata/index.rst
+++ b/source/shared/errata/index.rst
@@ -1,0 +1,21 @@
+:orphan:
+
+.. _known-issues-and-errata:
+
+.. only:: winsyslog or winsyslog_j or mwagent
+
+   Known issues and errata
+   =======================
+
+   This section documents confirmed product behavior that can affect operation
+   or the interpretation of collected data. Each notice identifies the
+   affected products and service versions, the practical impact, available
+   workarounds, and the planned or released correction.
+
+   Current errata
+   --------------
+
+   .. toctree::
+      :maxdepth: 1
+
+      err-2026-001-snmp-trap-source-address

--- a/source/winsyslogspecific/references.rst
+++ b/source/winsyslogspecific/references.rst
@@ -42,6 +42,16 @@ troubleshooting.
 
 .. include:: ../_generated/event-ids/winsyslog/navigation.inc
 
+.. only:: winsyslog or winsyslog_j or mwagent
+
+   Known issues and errata
+   -----------------------
+
+   .. toctree::
+      :maxdepth: 1
+
+      ../shared/errata/index
+
 External reference
 ------------------
 


### PR DESCRIPTION
## What

- add a reusable customer-facing known-issues and errata section
- document ERR-2026-001 for incorrect sender attribution by the SNMP Trap Receiver
- list affected WinSyslog and MonitorWare Agent service builds, last known unaffected builds, rollback cautions, and the planned 26.09 correction
- expose the shared notice only in WinSyslog, WinSyslog-J, and MonitorWare Agent through product-selection guards

## Why

Customers and partners need a stable, supportable notice that explains confirmed impact and workarounds without exposing private implementation evidence. A canonical shared entry also gives future release notes and version-history pages one durable source to reference.

## Validation

- warnings-as-errors HTML builds for all six product manuals
- spelling builds for all six product manuals
- `doc8`: 1,535 files, 0 errors
- `rstcheck`: 0 errors
- `git diff --check`
- rendered navigation and body checks confirm the notice appears in WinSyslog, WinSyslog-J, and MonitorWare Agent, and is absent from EventReporter, rsyslog Windows Agent, and SyslogViewer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a customer-facing known-issues and errata section and publishes ERR-2026-001 describing incorrect SNMP trap sender attribution. The shared notice appears only in WinSyslog, WinSyslog-J, and MonitorWare Agent.

- **New Features**
  - Added shared errata index and ERR-2026-001 explaining SNMP Trap Receiver recording the local host as source.
  - Documented affected builds, last known unaffected builds, and rollback cautions.
  - Noted correction planned for the 26.09 release and advised post-update verification.
  - Linked the section under References; visibility guarded to WinSyslog, WinSyslog-J, and MonitorWare Agent.

<sup>Written for commit cd676f9f5969ed142b9ba5b586c7c1254b37322b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Adiscon/adiscon-client-doc/pull/109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

